### PR TITLE
feat: rebrand from conductor to fridi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run tests
         if: matrix.os != 'ubuntu-latest'
-        run: cargo test --workspace --exclude conductor-ui --exclude conductor-agent
+        run: cargo test --workspace --exclude fridi-ui --exclude fridi-agent
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .DS_Store
 config.toml
 sessions/
-conductor-state.json
+fridi-state.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for conductor
+# Pre-commit hooks for fridi
 repos:
   # ============================================================================
   # FAST CHECKS - Run on every commit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,83 +411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conductor-agent"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "conductor-core",
- "portable-pty",
- "serde",
- "serde_json",
- "serde_yaml",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "conductor-core"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "petgraph",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_yaml",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "conductor-notify"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "reqwest",
- "serde",
- "serde_json",
- "temp-env",
- "thiserror 2.0.18",
- "tokio",
- "toml",
- "tracing",
- "wiremock",
-]
-
-[[package]]
-name = "conductor-trigger"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "conductor-core",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-cron-scheduler",
- "tracing",
-]
-
-[[package]]
-name = "conductor-ui"
-version = "0.1.0"
-dependencies = [
- "conductor-agent",
- "conductor-core",
- "conductor-notify",
- "conductor-trigger",
- "dioxus",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "const-serialize"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1588,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "fridi-agent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "fridi-core",
+ "portable-pty",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fridi-core"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "petgraph",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fridi-notify"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "temp-env",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
+name = "fridi-trigger"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "fridi-core",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-cron-scheduler",
+ "tracing",
+]
+
+[[package]]
+name = "fridi-ui"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "fridi-agent",
+ "fridi-core",
+ "fridi-notify",
+ "fridi-trigger",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,7 +2379,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3685,7 +3685,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.7+spec-1.1.0",
 ]
 
 [[package]]
@@ -4768,7 +4768,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -5028,9 +5028,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -5061,21 +5061,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "d15b06e6c39068c203e7c1d0bc3944796d867449e7668ef7fa5ea43727cb846e"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -5619,7 +5619,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -5643,7 +5643,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5684,7 +5684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -5696,7 +5696,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5713,12 +5713,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -5763,7 +5776,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -6255,7 +6268,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ license = "MIT"
 
 [workspace.dependencies]
 # Internal crates
-conductor-core = { path = "crates/core" }
-conductor-agent = { path = "crates/agent" }
-conductor-notify = { path = "crates/notify" }
-conductor-trigger = { path = "crates/trigger" }
+fridi-core = { path = "crates/core" }
+fridi-agent = { path = "crates/agent" }
+fridi-notify = { path = "crates/notify" }
+fridi-trigger = { path = "crates/trigger" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Dioxus.toml
+++ b/Dioxus.toml
@@ -1,3 +1,3 @@
 [application]
-name = "conductor-ui"
+name = "fridi-ui"
 default_platform = "desktop"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 conductor contributors
+Copyright (c) 2026 fridi contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-<img src="assets/logo.svg" width="80" height="80" alt="conductor logo">
+<img src="assets/logo.svg" width="80" height="80" alt="fridi logo">
 
-# conductor
+# fridi
 
-![Pre-commit](https://github.com/xdustinface/conductor/actions/workflows/pre-commit.yml/badge.svg) ![Tests](https://github.com/xdustinface/conductor/actions/workflows/test.yml/badge.svg) [![codecov](https://codecov.io/gh/xdustinface/conductor/graph/badge.svg)](https://codecov.io/gh/xdustinface/conductor) ![License](https://img.shields.io/badge/license-MIT-blue.svg)
+![Pre-commit](https://github.com/xdustinface/fridi/actions/workflows/pre-commit.yml/badge.svg) ![Tests](https://github.com/xdustinface/fridi/actions/workflows/test.yml/badge.svg) [![codecov](https://codecov.io/gh/xdustinface/fridi/graph/badge.svg)](https://codecov.io/gh/xdustinface/fridi) ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 
 </div>
 
-## What is conductor?
+## What is fridi?
 
-Conductor is an AI workflow orchestrator built in Rust. It lets you define
+Fridi is an AI workflow orchestrator built in Rust. It lets you define
 workflows as YAML-based DAGs, spawn AI coding agents (starting with the Claude
 CLI), observe them through a live desktop UI, and receive notifications when
 things need attention.
@@ -35,7 +35,7 @@ things need attention.
 ## Architecture
 
 ```text
-conductor/
+fridi/
 +-- crates/
 |   +-- core/       # Workflow schema, YAML parsing, DAG, execution engine, sessions
 |   +-- agent/      # Agent trait, PTY spawning, Claude CLI implementation
@@ -57,8 +57,8 @@ conductor/
 ### Build
 
 ```sh
-git clone https://github.com/xdustinface/conductor.git
-cd conductor
+git clone https://github.com/xdustinface/fridi.git
+cd fridi
 cargo build --workspace
 ```
 
@@ -78,7 +78,7 @@ cargo test --workspace
 ### Run the UI
 
 ```sh
-cargo run -p conductor-ui
+cargo run -p fridi-ui
 ```
 
 ## Workflow Example

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-# Clippy configuration for conductor
+# Clippy configuration for fridi

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "conductor-agent"
+name = "fridi-agent"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
-conductor-core = { workspace = true }
+fridi-core = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -74,7 +74,7 @@ impl Agent for ClaudeAgent {
 
         if !config.context.is_empty() {
             if let Ok(ctx_json) = serde_json::to_string(&config.context) {
-                cmd.env("CONDUCTOR_CONTEXT", &ctx_json);
+                cmd.env("FRIDI_CONTEXT", &ctx_json);
             }
         }
 

--- a/crates/agent/src/pty.rs
+++ b/crates/agent/src/pty.rs
@@ -145,12 +145,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_spawn_echo() {
         let mut cmd = CommandBuilder::new("echo");
-        cmd.arg("hello conductor");
+        cmd.arg("hello fridi");
         let mut proc = PtyProcess::spawn(cmd).unwrap();
         let exit_code = proc.wait().await.unwrap();
         assert_eq!(exit_code, 0);
         let output = proc.collected_output().await;
-        assert!(output.contains("hello conductor"), "output was: {output}");
+        assert!(output.contains("hello fridi"), "output was: {output}");
     }
 
     #[tokio::test]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "conductor-core"
+name = "fridi-core"
 version.workspace = true
 edition.workspace = true
 

--- a/crates/core/src/schema.rs
+++ b/crates/core/src/schema.rs
@@ -267,10 +267,10 @@ steps:
 
     #[test]
     fn test_env_interpolation() {
-        std::env::set_var("TEST_CONDUCTOR_VAR", "hello");
-        assert_eq!(interpolate_env("${TEST_CONDUCTOR_VAR}"), "hello");
+        std::env::set_var("TEST_FRIDI_VAR", "hello");
+        assert_eq!(interpolate_env("${TEST_FRIDI_VAR}"), "hello");
         assert_eq!(interpolate_env("no_vars"), "no_vars");
-        std::env::remove_var("TEST_CONDUCTOR_VAR");
+        std::env::remove_var("TEST_FRIDI_VAR");
     }
 
     #[test]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -575,7 +575,7 @@ mod tests {
 
     #[test]
     fn test_store_list_nonexistent_dir() {
-        let store = SessionStore::new("/tmp/conductor-test-nonexistent-dir-xyz");
+        let store = SessionStore::new("/tmp/fridi-test-nonexistent-dir-xyz");
         let list = store.list().unwrap();
         assert!(list.is_empty());
     }

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "conductor-notify"
+name = "fridi-notify"
 version.workspace = true
 edition.workspace = true
 

--- a/crates/notify/src/config.rs
+++ b/crates/notify/src/config.rs
@@ -50,13 +50,13 @@ impl NotifyConfig {
     }
 
     pub fn from_env() -> Self {
-        let slack = Self::non_empty_env("CONDUCTOR_SLACK_WEBHOOK_URL").map(|url| SlackConfig {
+        let slack = Self::non_empty_env("FRIDI_SLACK_WEBHOOK_URL").map(|url| SlackConfig {
             webhook_url: url,
-            channel: Self::non_empty_env("CONDUCTOR_SLACK_CHANNEL"),
+            channel: Self::non_empty_env("FRIDI_SLACK_CHANNEL"),
         });
 
-        let telegram = Self::non_empty_env("CONDUCTOR_TELEGRAM_BOT_TOKEN").and_then(|token| {
-            Self::non_empty_env("CONDUCTOR_TELEGRAM_CHAT_ID").map(|chat_id| TelegramConfig {
+        let telegram = Self::non_empty_env("FRIDI_TELEGRAM_BOT_TOKEN").and_then(|token| {
+            Self::non_empty_env("FRIDI_TELEGRAM_CHAT_ID").map(|chat_id| TelegramConfig {
                 bot_token: token,
                 chat_id,
             })
@@ -96,12 +96,12 @@ mod tests {
         temp_env::with_vars(
             [
                 (
-                    "CONDUCTOR_SLACK_WEBHOOK_URL",
+                    "FRIDI_SLACK_WEBHOOK_URL",
                     Some("https://hooks.slack.com/test"),
                 ),
-                ("CONDUCTOR_SLACK_CHANNEL", Some("#alerts")),
-                ("CONDUCTOR_TELEGRAM_BOT_TOKEN", Some("123:ABC")),
-                ("CONDUCTOR_TELEGRAM_CHAT_ID", Some("-100123")),
+                ("FRIDI_SLACK_CHANNEL", Some("#alerts")),
+                ("FRIDI_TELEGRAM_BOT_TOKEN", Some("123:ABC")),
+                ("FRIDI_TELEGRAM_CHAT_ID", Some("-100123")),
             ],
             || {
                 let config = NotifyConfig::from_env();
@@ -121,10 +121,10 @@ mod tests {
     fn test_config_from_env_ignores_empty_vars() {
         temp_env::with_vars(
             [
-                ("CONDUCTOR_SLACK_WEBHOOK_URL", Some("")),
-                ("CONDUCTOR_SLACK_CHANNEL", Some("  ")),
-                ("CONDUCTOR_TELEGRAM_BOT_TOKEN", Some("")),
-                ("CONDUCTOR_TELEGRAM_CHAT_ID", Some("-100123")),
+                ("FRIDI_SLACK_WEBHOOK_URL", Some("")),
+                ("FRIDI_SLACK_CHANNEL", Some("  ")),
+                ("FRIDI_TELEGRAM_BOT_TOKEN", Some("")),
+                ("FRIDI_TELEGRAM_CHAT_ID", Some("-100123")),
             ],
             || {
                 let config = NotifyConfig::from_env();

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "conductor-trigger"
+name = "fridi-trigger"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
-conductor-core = { workspace = true }
+fridi-core = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "conductor-ui"
+name = "fridi-ui"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
-conductor-core = { workspace = true }
-conductor-agent = { workspace = true }
-conductor-notify = { workspace = true }
-conductor-trigger = { workspace = true }
+fridi-core = { workspace = true }
+fridi-agent = { workspace = true }
+fridi-notify = { workspace = true }
+fridi-trigger = { workspace = true }
 dioxus = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use conductor_core::engine::StepStatus;
 use dioxus::prelude::*;
+use fridi_core::engine::StepStatus;
 
 use crate::components::sidebar::Sidebar;
 use crate::components::workflow_view::WorkflowView;

--- a/crates/ui/src/components/sidebar.rs
+++ b/crates/ui/src/components/sidebar.rs
@@ -11,7 +11,7 @@ pub(crate) fn Sidebar(
     rsx! {
         div { class: "sidebar",
             div { class: "sidebar-header",
-                h1 { "conductor" }
+                h1 { "fridi" }
                 p { "AI Workflow Orchestrator" }
             }
             div { class: "workflow-list",

--- a/crates/ui/src/components/step_card.rs
+++ b/crates/ui/src/components/step_card.rs
@@ -1,6 +1,6 @@
-use conductor_core::engine::StepStatus;
-use conductor_core::schema::Step;
 use dioxus::prelude::*;
+use fridi_core::engine::StepStatus;
+use fridi_core::schema::Step;
 
 #[component]
 pub(crate) fn StepCard(step: Step, status: Option<StepStatus>) -> Element {

--- a/crates/ui/src/components/workflow_view.rs
+++ b/crates/ui/src/components/workflow_view.rs
@@ -1,6 +1,6 @@
-use conductor_core::engine::StepStatus;
-use conductor_core::schema::Trigger;
 use dioxus::prelude::*;
+use fridi_core::engine::StepStatus;
+use fridi_core::schema::Trigger;
 
 use crate::components::step_card::StepCard;
 use crate::state::{RunState, WorkflowState};

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use conductor_core::engine::StepStatus;
-use conductor_core::schema::Workflow;
+use fridi_core::engine::StepStatus;
+use fridi_core::schema::Workflow;
 
 /// Represents a loaded workflow and its current run state
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
## Summary

- Rename all crate packages: `conductor-*` → `fridi-*`
- Rename all Rust imports: `conductor_*` → `fridi_*`
- Rename all env vars: `CONDUCTOR_*` → `FRIDI_*`
- Update Dioxus.toml, README, .gitignore, LICENSE, agent definitions
- Update CI workflow references
- Zero remaining "conductor" references in any source file

Named after Friedrich — in memory of a grandfather who introduced the creator to coding.

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rebranded project from "conductor" to "fridi" across codebase, including package names, environment variables, and configuration files.
  * Updated configuration file references (`conductor-state.json` → `fridi-state.json`).
  * Updated environment variable names for configuration reading.
  * Updated UI sidebar branding text.

* **Documentation**
  * Updated README and LICENSE with new project branding and repository references.

* **Tests**
  * Updated test fixtures and assertions to reflect naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->