### PR TITLE
fix(ci): enable verbose pre-commit output

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,4 +52,4 @@ jobs:
         run: pip install pre-commit
 
       - name: Run pre-commit
-        run: pre-commit run --all-files --hook-stage pre-push
+        run: pre-commit run --all-files --hook-stage pre-push --verbose


### PR DESCRIPTION
Adds --verbose to pre-commit run in CI for timing analysis.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit CI workflow logging with increased verbosity to provide more detailed output during code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->