### PR TITLE
feat(core): add session recovery with window state persistence

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod engine;
 pub mod github;
 pub mod schema;
 pub mod session;
+pub mod window_state;
 
 pub use dag::WorkflowDag;
 pub use engine::Engine;
@@ -11,3 +12,4 @@ pub use session::{
     Session, SessionId, SessionStatus, SessionStore, SessionStoreError, SessionSummary,
     StepSession, StepSessionId,
 };
+pub use window_state::WindowState;

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -124,6 +124,22 @@ impl Session {
         self.status = self.derive_status();
     }
 
+    /// Mark any steps that were `Running` at shutdown as `Failed("interrupted")`,
+    /// and set the session status to `Interrupted`.
+    pub fn mark_interrupted(&mut self) {
+        let mut had_running = false;
+        for step in self.steps.values_mut() {
+            if step.status == StepStatus::Running {
+                step.status = StepStatus::Failed("interrupted".into());
+                had_running = true;
+            }
+        }
+        if had_running || self.status == SessionStatus::Running {
+            self.status = SessionStatus::Interrupted;
+            self.updated_at = Utc::now();
+        }
+    }
+
     pub fn derive_status(&self) -> SessionStatus {
         let mut has_running = false;
         let mut has_failed = false;
@@ -246,6 +262,34 @@ impl SessionStore {
         }
         summaries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
         Ok(summaries)
+    }
+
+    /// Load all sessions, marking any that were `Running` as `Interrupted`.
+    /// Interrupted sessions are persisted back to disk.
+    pub fn load_all_and_recover(&self) -> Result<Vec<Session>, SessionStoreError> {
+        if !self.base_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut sessions = Vec::new();
+        for entry in fs::read_dir(&self.base_dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let session_file = entry.path().join("session.json");
+            if session_file.exists() {
+                let content = fs::read_to_string(&session_file)?;
+                let mut session: Session = serde_json::from_str(&content)?;
+                if session.status == SessionStatus::Running {
+                    session.mark_interrupted();
+                    self.save(&session)?;
+                }
+                sessions.push(session);
+            }
+        }
+        sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(sessions)
     }
 
     pub fn delete(&self, id: &SessionId) -> Result<(), SessionStoreError> {
@@ -586,5 +630,139 @@ mod tests {
         assert!(!id.as_str().contains('/'));
         assert!(!id.as_str().contains('\\'));
         assert!(!id.as_str().contains(".."));
+    }
+
+    #[test]
+    fn test_interrupted_session_detection() {
+        let mut session = Session::new(
+            SessionId::new("wf"),
+            "wf".into(),
+            "wf.yaml".into(),
+            Some("owner/repo".into()),
+        );
+
+        // Add a completed step and a running step
+        session.update_step(
+            StepSessionId::new("done", 1),
+            StepSession {
+                step_name: "done".into(),
+                attempt: 1,
+                status: StepStatus::Completed,
+                claude_session_id: Some("sess-1".into()),
+                output_summary: None,
+                started_at: Some(Utc::now()),
+                finished_at: Some(Utc::now()),
+            },
+        );
+        session.update_step(
+            StepSessionId::new("active", 1),
+            StepSession {
+                step_name: "active".into(),
+                attempt: 1,
+                status: StepStatus::Running,
+                claude_session_id: Some("sess-2".into()),
+                output_summary: None,
+                started_at: Some(Utc::now()),
+                finished_at: None,
+            },
+        );
+
+        assert_eq!(session.status, SessionStatus::Running);
+
+        session.mark_interrupted();
+
+        assert_eq!(session.status, SessionStatus::Interrupted);
+
+        // The running step should be marked as failed with "interrupted"
+        let active_step = &session.steps[&StepSessionId::new("active", 1)];
+        assert!(matches!(&active_step.status, StepStatus::Failed(msg) if msg == "interrupted"));
+
+        // The completed step should remain unchanged
+        let done_step = &session.steps[&StepSessionId::new("done", 1)];
+        assert_eq!(done_step.status, StepStatus::Completed);
+    }
+
+    #[test]
+    fn test_mark_interrupted_no_running_steps() {
+        let mut session = Session::new(SessionId::new("wf"), "wf".into(), "wf.yaml".into(), None);
+        session.update_step(
+            StepSessionId::new("s1", 1),
+            StepSession {
+                step_name: "s1".into(),
+                attempt: 1,
+                status: StepStatus::Completed,
+                claude_session_id: None,
+                output_summary: None,
+                started_at: None,
+                finished_at: None,
+            },
+        );
+        // Force status to completed
+        session.status = SessionStatus::Completed;
+
+        session.mark_interrupted();
+
+        // Should not change status if already completed with no running steps
+        assert_eq!(session.status, SessionStatus::Completed);
+    }
+
+    #[test]
+    fn test_load_all_and_recover() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path());
+
+        // Save a running session
+        let mut running = Session::new(
+            SessionId::new("running"),
+            "running".into(),
+            "r.yaml".into(),
+            None,
+        );
+        running.update_step(
+            StepSessionId::new("step", 1),
+            StepSession {
+                step_name: "step".into(),
+                attempt: 1,
+                status: StepStatus::Running,
+                claude_session_id: Some("sess-abc".into()),
+                output_summary: None,
+                started_at: Some(Utc::now()),
+                finished_at: None,
+            },
+        );
+        store.save(&running).unwrap();
+
+        // Save a completed session
+        let mut completed =
+            Session::new(SessionId::new("done"), "done".into(), "d.yaml".into(), None);
+        completed.update_step(
+            StepSessionId::new("step", 1),
+            StepSession {
+                step_name: "step".into(),
+                attempt: 1,
+                status: StepStatus::Completed,
+                claude_session_id: None,
+                output_summary: None,
+                started_at: None,
+                finished_at: None,
+            },
+        );
+        store.save(&completed).unwrap();
+
+        let sessions = store.load_all_and_recover().unwrap();
+        assert_eq!(sessions.len(), 2);
+
+        let recovered = sessions
+            .iter()
+            .find(|s| s.workflow_name == "running")
+            .unwrap();
+        assert_eq!(recovered.status, SessionStatus::Interrupted);
+
+        let still_done = sessions.iter().find(|s| s.workflow_name == "done").unwrap();
+        assert_eq!(still_done.status, SessionStatus::Completed);
+
+        // Verify the interrupted session was persisted to disk
+        let reloaded = store.load(&running.id).unwrap();
+        assert_eq!(reloaded.status, SessionStatus::Interrupted);
     }
 }

--- a/crates/core/src/window_state.rs
+++ b/crates/core/src/window_state.rs
@@ -1,0 +1,176 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::{fs, io};
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WindowState {
+    pub windows: HashMap<String, WindowInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowInfo {
+    pub open_sessions: Vec<String>,
+    pub active_tab: Option<String>,
+}
+
+impl WindowState {
+    pub fn load(path: &Path) -> Self {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        let tmp_name = format!(
+            "{}.{:016x}.tmp",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            rand::thread_rng().gen::<u64>()
+        );
+        let tmp_path = path.with_file_name(tmp_name);
+        fs::write(&tmp_path, &json)?;
+        fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+
+    pub fn update_tab(&mut self, repo: &str, session_id: &str, is_open: bool) {
+        let info = self
+            .windows
+            .entry(repo.to_string())
+            .or_insert_with(|| WindowInfo {
+                open_sessions: Vec::new(),
+                active_tab: None,
+            });
+
+        if is_open {
+            if !info.open_sessions.iter().any(|s| s == session_id) {
+                info.open_sessions.push(session_id.to_string());
+            }
+        } else {
+            info.open_sessions.retain(|s| s != session_id);
+            if info.active_tab.as_deref() == Some(session_id) {
+                info.active_tab = info.open_sessions.last().cloned();
+            }
+        }
+    }
+
+    pub fn set_active(&mut self, repo: &str, session_id: &str) {
+        if let Some(info) = self.windows.get_mut(repo) {
+            if info.open_sessions.iter().any(|s| s == session_id) {
+                info.active_tab = Some(session_id.to_string());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn test_window_state_save_load() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("fridi-state.json");
+
+        let mut state = WindowState::default();
+        state.update_tab("owner/repo", "session-1", true);
+        state.update_tab("owner/repo", "session-2", true);
+        state.set_active("owner/repo", "session-2");
+
+        state.save(&path).unwrap();
+        let loaded = WindowState::load(&path);
+
+        let info = loaded.windows.get("owner/repo").unwrap();
+        assert_eq!(info.open_sessions, vec!["session-1", "session-2"]);
+        assert_eq!(info.active_tab.as_deref(), Some("session-2"));
+    }
+
+    #[test]
+    fn test_window_state_update_tab() {
+        let mut state = WindowState::default();
+
+        state.update_tab("owner/repo", "s1", true);
+        state.update_tab("owner/repo", "s2", true);
+        assert_eq!(state.windows["owner/repo"].open_sessions, vec!["s1", "s2"]);
+
+        // Adding a duplicate does nothing
+        state.update_tab("owner/repo", "s1", true);
+        assert_eq!(state.windows["owner/repo"].open_sessions, vec!["s1", "s2"]);
+
+        // Removing a tab
+        state.update_tab("owner/repo", "s1", false);
+        assert_eq!(state.windows["owner/repo"].open_sessions, vec!["s2"]);
+    }
+
+    #[test]
+    fn test_window_state_set_active() {
+        let mut state = WindowState::default();
+        state.update_tab("owner/repo", "s1", true);
+        state.update_tab("owner/repo", "s2", true);
+
+        state.set_active("owner/repo", "s1");
+        assert_eq!(
+            state.windows["owner/repo"].active_tab.as_deref(),
+            Some("s1")
+        );
+
+        state.set_active("owner/repo", "s2");
+        assert_eq!(
+            state.windows["owner/repo"].active_tab.as_deref(),
+            Some("s2")
+        );
+
+        // Setting active on a session that is not open does nothing
+        state.set_active("owner/repo", "s3");
+        assert_eq!(
+            state.windows["owner/repo"].active_tab.as_deref(),
+            Some("s2")
+        );
+    }
+
+    #[test]
+    fn test_window_state_missing_file() {
+        let state = WindowState::load(Path::new("/tmp/fridi-nonexistent-state-xyz.json"));
+        assert!(state.windows.is_empty());
+    }
+
+    #[test]
+    fn test_window_state_close_active_tab_selects_last() {
+        let mut state = WindowState::default();
+        state.update_tab("r", "s1", true);
+        state.update_tab("r", "s2", true);
+        state.update_tab("r", "s3", true);
+        state.set_active("r", "s2");
+
+        // Closing the active tab should select the last remaining session
+        state.update_tab("r", "s2", false);
+        assert_eq!(state.windows["r"].active_tab.as_deref(), Some("s3"));
+    }
+
+    #[test]
+    fn test_window_state_atomic_write() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("fridi-state.json");
+
+        let state = WindowState::default();
+        state.save(&path).unwrap();
+
+        // No .tmp files should remain
+        let tmp_files: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(tmp_files.is_empty());
+        assert!(path.exists());
+    }
+}

--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use dioxus::prelude::*;
 use fridi_core::session::{Session, SessionId, SessionStore};
+use fridi_core::window_state::WindowState;
 
 use crate::components::session_creator::{SessionCreator, SessionSource};
 use crate::components::tab_bar::TabBar;
@@ -10,6 +11,7 @@ use crate::state::{self, TabInfo};
 use crate::styles;
 
 const SESSIONS_DIR: &str = ".fridi/sessions";
+const STATE_FILE: &str = ".fridi/fridi-state.json";
 
 #[component]
 pub(crate) fn App() -> Element {
@@ -17,18 +19,7 @@ pub(crate) fn App() -> Element {
     let workflows = use_signal(|| state::load_workflows(&workflows_dir));
 
     let store = use_signal(|| SessionStore::new(SESSIONS_DIR));
-
-    let mut tabs = use_signal(|| {
-        let summaries = state::load_sessions(&store.read());
-        summaries.iter().map(TabInfo::from).collect::<Vec<_>>()
-    });
-
-    let mut active_tab = use_signal(|| {
-        let t = tabs.read();
-        if t.is_empty() { None } else { Some(0) }
-    });
-
-    let mut showing_creator = use_signal(|| false);
+    let state_path = use_signal(|| PathBuf::from(STATE_FILE));
 
     // Derive repo from the first workflow that has one configured
     let default_repo: Option<String> = workflows
@@ -36,6 +27,51 @@ pub(crate) fn App() -> Element {
         .iter()
         .find_map(|(wf, _)| wf.config.repo.clone())
         .filter(|r| !r.is_empty());
+
+    // On startup: load window state and recover sessions
+    let mut window_state = use_signal(|| state::load_window_state(&state_path.read()));
+
+    let mut tabs = use_signal(|| {
+        let sessions = state::load_sessions_with_recovery(&store.read());
+        let repo_key = default_repo.clone().unwrap_or_default();
+        let ws = state::load_window_state(&state_path.read());
+        let (restored, _) = state::restore_tabs(&ws, &sessions, &repo_key);
+        if restored.is_empty() {
+            // Fall back to showing all sessions as tabs
+            sessions
+                .iter()
+                .map(|s| TabInfo {
+                    session_id: s.id.clone(),
+                    workflow_name: s.workflow_name.clone(),
+                    status: s.status.clone(),
+                })
+                .collect::<Vec<_>>()
+        } else {
+            restored
+        }
+    });
+
+    let mut active_tab = use_signal(|| {
+        let sessions = state::load_sessions_with_recovery(&store.read());
+        let repo_key = default_repo.clone().unwrap_or_default();
+        let ws = state::load_window_state(&state_path.read());
+        let (restored, active_idx) = state::restore_tabs(&ws, &sessions, &repo_key);
+        if restored.is_empty() {
+            let t = tabs.read();
+            if t.is_empty() { None } else { Some(0) }
+        } else {
+            active_idx
+        }
+    });
+
+    let mut showing_creator = use_signal(|| false);
+
+    // Helper to persist window state after tab changes
+    let save_window_state = move |ws: &WindowState| {
+        if let Err(e) = ws.save(&state_path.read()) {
+            eprintln!("failed to save window state: {e}");
+        }
+    };
 
     // Load the full session for the active tab
     let active_session: Option<Session> = {
@@ -48,15 +84,34 @@ pub(crate) fn App() -> Element {
         })
     };
 
+    let repo_for_select = default_repo.clone();
     let on_select_tab = move |idx: usize| {
         active_tab.set(Some(idx));
+        // Persist active tab change
+        let tabs_read = tabs.read();
+        if let Some(tab) = tabs_read.get(idx) {
+            let repo_key = repo_for_select.clone().unwrap_or_default();
+            let mut ws = window_state.write();
+            ws.set_active(&repo_key, tab.session_id.as_str());
+            save_window_state(&ws);
+        }
     };
 
+    let repo_for_close = default_repo.clone();
     let on_close_tab = move |idx: usize| {
         let mut t = tabs.write();
         if idx < t.len() {
+            let closed_session_id = t[idx].session_id.as_str().to_string();
             t.remove(idx);
             let len = t.len();
+
+            // Persist tab removal
+            let repo_key = repo_for_close.clone().unwrap_or_default();
+            let mut ws = window_state.write();
+            ws.update_tab(&repo_key, &closed_session_id, false);
+            save_window_state(&ws);
+            drop(ws);
+
             drop(t);
             if len == 0 {
                 active_tab.set(None);
@@ -75,6 +130,7 @@ pub(crate) fn App() -> Element {
         showing_creator.set(true);
     };
 
+    let repo_for_create = default_repo.clone();
     let on_create_session = move |source: SessionSource| {
         let (workflow_name, context_label) = match &source {
             SessionSource::Issue { number, title } => (
@@ -118,7 +174,7 @@ pub(crate) fn App() -> Element {
         }
 
         let tab = TabInfo {
-            session_id,
+            session_id: session_id.clone(),
             workflow_name: context_label,
             status: session.status.clone(),
         };
@@ -128,6 +184,13 @@ pub(crate) fn App() -> Element {
         drop(t);
         active_tab.set(Some(new_idx));
         showing_creator.set(false);
+
+        // Persist new tab in window state
+        let repo_key = repo_for_create.clone().unwrap_or_default();
+        let mut ws = window_state.write();
+        ws.update_tab(&repo_key, session_id.as_str(), true);
+        ws.set_active(&repo_key, session_id.as_str());
+        save_window_state(&ws);
     };
 
     let on_cancel_creator = move |()| {

--- a/crates/ui/src/state.rs
+++ b/crates/ui/src/state.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use fridi_core::schema::Workflow;
-use fridi_core::session::{SessionId, SessionStatus, SessionStore, SessionSummary};
+use fridi_core::session::{Session, SessionId, SessionStatus, SessionStore};
+use fridi_core::window_state::WindowState;
 
 /// Information about a tab displayed in the tab bar
 #[derive(Debug, Clone, PartialEq)]
@@ -9,16 +10,6 @@ pub(crate) struct TabInfo {
     pub(crate) session_id: SessionId,
     pub(crate) workflow_name: String,
     pub(crate) status: SessionStatus,
-}
-
-impl From<&SessionSummary> for TabInfo {
-    fn from(summary: &SessionSummary) -> Self {
-        Self {
-            session_id: summary.id.clone(),
-            workflow_name: summary.workflow_name.clone(),
-            status: summary.status.clone(),
-        }
-    }
 }
 
 /// Load all workflow files from a directory, returning each workflow with its source path
@@ -40,13 +31,51 @@ pub(crate) fn load_workflows(dir: &std::path::Path) -> Vec<(Workflow, PathBuf)> 
     workflows
 }
 
-/// Load session summaries from the session store
-pub(crate) fn load_sessions(store: &SessionStore) -> Vec<SessionSummary> {
-    match store.list() {
-        Ok(summaries) => summaries,
+/// Restore tabs from window state, filtering to sessions that still exist.
+/// Returns the tabs and the index of the active tab.
+pub(crate) fn restore_tabs(
+    window_state: &WindowState,
+    sessions: &[Session],
+    repo: &str,
+) -> (Vec<TabInfo>, Option<usize>) {
+    let Some(info) = window_state.windows.get(repo) else {
+        return (Vec::new(), None);
+    };
+
+    let mut tabs = Vec::new();
+    let mut active_idx = None;
+
+    for sid in &info.open_sessions {
+        if let Some(session) = sessions.iter().find(|s| s.id.as_str() == sid) {
+            let idx = tabs.len();
+            if info.active_tab.as_deref() == Some(sid.as_str()) {
+                active_idx = Some(idx);
+            }
+            tabs.push(TabInfo {
+                session_id: session.id.clone(),
+                workflow_name: session.workflow_name.clone(),
+                status: session.status.clone(),
+            });
+        }
+    }
+
+    if active_idx.is_none() && !tabs.is_empty() {
+        active_idx = Some(0);
+    }
+
+    (tabs, active_idx)
+}
+
+/// Load all sessions with recovery (marks running sessions as interrupted).
+pub(crate) fn load_sessions_with_recovery(store: &SessionStore) -> Vec<Session> {
+    match store.load_all_and_recover() {
+        Ok(sessions) => sessions,
         Err(e) => {
             eprintln!("failed to load sessions: {e}");
             Vec::new()
         }
     }
 }
+
+/// Load window state from the given path.
+pub(crate) fn load_window_state(state_path: &Path) -> WindowState { WindowState::load(state_path) }


### PR DESCRIPTION
## Summary

- New `WindowState` for tracking open tabs per repo window, persisted to `fridi-state.json`
- `Session::mark_interrupted()` marks running sessions as interrupted on recovery
- `SessionStore::load_all_and_recover()` auto-recovers interrupted sessions on startup
- UI startup restores tabs from `WindowState`, tab open/close/select persisted in real-time
- 9 new tests covering persistence, recovery, and interrupted session detection

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session recovery: sessions interrupted during shutdown are now automatically recovered and marked as failed on startup.
  * Persistent window state: the application now remembers which tabs were open and which tab was active between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->