### PR TITLE
feat(agent): add mcp_config to AgentConfig and pass --mcp-config to Claude CLI

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -84,6 +84,11 @@ impl Agent for ClaudeAgent {
             cmd.arg(prompt);
         }
 
+        if let Some(mcp_config_path) = &config.mcp_config {
+            cmd.arg("--mcp-config");
+            cmd.arg(mcp_config_path);
+        }
+
         if let Some(dir) = &config.working_dir {
             cmd.cwd(dir);
         }
@@ -228,6 +233,26 @@ mod tests {
                 "generated session id is not a valid UUID: {sid}"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_claude_agent_mcp_config() {
+        let config = AgentConfig {
+            agent_type: "claude".into(),
+            mcp_config: Some("/tmp/mcp-config.json".to_string()),
+            ..Default::default()
+        };
+        let mut handle = spawn_echo_agent(config).await;
+        let _ = handle.wait().await;
+        let output = handle.collected_output();
+        assert!(
+            output.contains("--mcp-config"),
+            "expected --mcp-config in output: {output}"
+        );
+        assert!(
+            output.contains("/tmp/mcp-config.json"),
+            "expected mcp config path in output: {output}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/agent/src/traits.rs
+++ b/crates/agent/src/traits.rs
@@ -38,6 +38,8 @@ pub struct AgentConfig {
     pub resume: bool,
     /// Human-readable name for the session
     pub session_name: Option<String>,
+    /// Path to an MCP config JSON file to pass via `--mcp-config`
+    pub mcp_config: Option<String>,
 }
 
 #[async_trait]

--- a/crates/mcp/src/config.rs
+++ b/crates/mcp/src/config.rs
@@ -4,13 +4,13 @@ use serde_json::{Value as JsonValue, json};
 ///
 /// The generated config describes a single stdio-based MCP server at the given
 /// socket path. Claude CLI reads this to discover available MCP tools.
-pub fn generate_mcp_config(socket_path: &str) -> JsonValue {
+pub fn generate_mcp_config(socket_path: &str, agent_id: &str) -> JsonValue {
     json!({
         "mcpServers": {
             "fridi": {
                 "type": "stdio",
                 "command": "fridi-mcp-server",
-                "args": ["--socket", socket_path],
+                "args": ["--socket", socket_path, "--agent-id", agent_id],
                 "env": {}
             }
         }
@@ -23,7 +23,7 @@ mod tests {
 
     #[test]
     fn test_mcp_config_generation() {
-        let config = generate_mcp_config("/tmp/fridi.sock");
+        let config = generate_mcp_config("/tmp/fridi.sock", "agent-1");
 
         assert!(config.get("mcpServers").is_some());
         let servers = &config["mcpServers"];
@@ -34,15 +34,18 @@ mod tests {
         assert_eq!(fridi["command"], "fridi-mcp-server");
 
         let args = fridi["args"].as_array().unwrap();
-        assert_eq!(args.len(), 2);
+        assert_eq!(args.len(), 4);
         assert_eq!(args[0], "--socket");
         assert_eq!(args[1], "/tmp/fridi.sock");
+        assert_eq!(args[2], "--agent-id");
+        assert_eq!(args[3], "agent-1");
     }
 
     #[test]
     fn test_mcp_config_different_paths() {
-        let config = generate_mcp_config("/var/run/mcp/agent-123.sock");
-        let path = config["mcpServers"]["fridi"]["args"][1].as_str().unwrap();
-        assert_eq!(path, "/var/run/mcp/agent-123.sock");
+        let config = generate_mcp_config("/var/run/mcp/agent-123.sock", "planner");
+        let args = config["mcpServers"]["fridi"]["args"].as_array().unwrap();
+        assert_eq!(args[1].as_str().unwrap(), "/var/run/mcp/agent-123.sock");
+        assert_eq!(args[3].as_str().unwrap(), "planner");
     }
 }


### PR DESCRIPTION
## Summary

- Add `mcp_config: Option<String>` to `AgentConfig`
- Pass `--mcp-config <path>` to Claude CLI when set
- Update `generate_mcp_config()` to accept `agent_id` and pass `--agent-id`
- Test verifying the flag appears in the command

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Model Context Protocol (MCP) configuration support to agents.
  * Agents now accept an optional MCP config file path that is passed during initialization.
  * Agent identifiers are now included in MCP server communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->