### PR TITLE
feat(cli): implement fridi run <workflow.yaml> entry point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,14 +1707,14 @@ name = "fridi-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "clap",
  "fridi-agent",
  "fridi-core",
  "fridi-mcp",
  "serde_json",
- "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2506,7 +2506,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3824,7 +3824,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -4913,7 +4913,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -5173,9 +5173,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -5206,21 +5206,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -5770,7 +5770,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -5794,7 +5794,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5835,7 +5835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -5847,7 +5847,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5864,12 +5864,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -5914,7 +5927,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -6406,7 +6419,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/cli",
     "crates/core",
     "crates/agent",
     "crates/mcp",
     "crates/notify",
     "crates/trigger",
     "crates/ui",
-    "crates/cli",
 ]
 
 [workspace.package]
@@ -21,6 +21,7 @@ fridi-core = { path = "crates/core" }
 fridi-agent = { path = "crates/agent" }
 fridi-mcp = { path = "crates/mcp" }
 fridi-notify = { path = "crates/notify" }
+fridi-cli = { path = "crates/cli" }
 fridi-trigger = { path = "crates/trigger" }
 
 # Serialization

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "fridi-cli"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "fridi"
@@ -11,11 +12,9 @@ path = "src/main.rs"
 fridi-core = { workspace = true }
 fridi-agent = { workspace = true }
 fridi-mcp = { workspace = true }
+anyhow = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-serde_json = { workspace = true }
-async-trait = { workspace = true }
-anyhow = { workspace = true }
-
-[dev-dependencies]
-tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,1 +1,0 @@
-pub mod spawner;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,55 @@
-fn main() {
-    eprintln!("fridi CLI — not yet implemented. See issue #46.");
-    std::process::exit(1);
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+mod run;
+mod spawner;
+
+#[derive(Parser)]
+#[command(name = "fridi", about = "AI workflow orchestrator")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run a workflow from a YAML file
+    Run {
+        /// Path to the workflow YAML file
+        workflow: PathBuf,
+
+        /// Repository in owner/repo format
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Directory containing agent definition YAML files
+        #[arg(long, default_value = "agents")]
+        agents_dir: PathBuf,
+
+        /// Directory for session storage
+        #[arg(long, default_value = ".fridi/sessions")]
+        sessions_dir: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Run {
+            workflow,
+            repo,
+            agents_dir,
+            sessions_dir,
+        } => run::execute(workflow, repo, agents_dir, sessions_dir).await,
+    }
 }

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -1,0 +1,119 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use fridi_agent::claude::ClaudeAgentConfig;
+use fridi_agent::definition::load_agent_definitions;
+use fridi_core::dag::WorkflowDag;
+use fridi_core::engine::{Engine, EngineEvent, StepStatus};
+use fridi_core::orchestrator::Orchestrator;
+use fridi_core::schema::Workflow;
+use fridi_core::session::{Session, SessionId, SessionStore};
+use tokio::sync::Mutex;
+
+use crate::spawner::OrchestratorSpawner;
+
+pub(crate) async fn execute(
+    workflow_path: PathBuf,
+    repo: Option<String>,
+    agents_dir: PathBuf,
+    sessions_dir: PathBuf,
+) -> anyhow::Result<()> {
+    let workflow = Workflow::from_file(&workflow_path)?;
+    tracing::info!("loaded workflow: {}", workflow.name);
+
+    let dag = WorkflowDag::from_workflow(&workflow)?;
+    tracing::info!("built DAG with {} steps", dag.step_count());
+
+    let session_id = SessionId::new(&workflow.name);
+    let repo_name = repo.or_else(|| workflow.config.repo.clone());
+    let session = Session::new(
+        session_id.clone(),
+        workflow.name.clone(),
+        workflow_path.to_string_lossy().into(),
+        repo_name.clone(),
+    );
+    let store = SessionStore::new(&sessions_dir);
+    store.save(&session)?;
+    tracing::info!("created session: {}", session_id);
+
+    let session_dir = sessions_dir.join(session_id.as_str());
+    let orchestrator = Orchestrator::from_agents_dir(
+        session,
+        store,
+        &agents_dir,
+        repo_name.as_deref().unwrap_or(""),
+        session_dir.clone(),
+    )?;
+    let orchestrator = Arc::new(Mutex::new(orchestrator));
+
+    let (engine, mut event_rx) = Engine::new();
+
+    tokio::spawn(async move {
+        while let Ok(event) = event_rx.recv().await {
+            match &event {
+                EngineEvent::WorkflowStarted { workflow_name } => {
+                    println!("[workflow] started: {}", workflow_name);
+                }
+                EngineEvent::StepStatusChanged { step_name, status } => {
+                    let status_str = match status {
+                        StepStatus::Pending => "pending",
+                        StepStatus::Running => "running",
+                        StepStatus::Completed => "completed",
+                        StepStatus::Failed(reason) => {
+                            println!("[step] {} -> failed: {}", step_name, reason);
+                            continue;
+                        }
+                        StepStatus::Skipped => "skipped",
+                    };
+                    println!("[step] {} -> {}", step_name, status_str);
+                }
+                EngineEvent::WorkflowCompleted { workflow_name } => {
+                    println!("[workflow] completed: {}", workflow_name);
+                }
+                EngineEvent::WorkflowFailed {
+                    workflow_name,
+                    reason,
+                } => {
+                    println!("[workflow] failed: {} -- {}", workflow_name, reason);
+                }
+                EngineEvent::NotificationRequired {
+                    step_name, message, ..
+                } => {
+                    println!("[notify] {} -- {}", step_name, message);
+                }
+            }
+        }
+    });
+
+    let agent_definitions = if agents_dir.exists() {
+        load_agent_definitions(&agents_dir).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let mcp_socket_path = session_dir.join("mcp.sock").to_string_lossy().into_owned();
+    let spawner = OrchestratorSpawner::new(
+        orchestrator,
+        ClaudeAgentConfig::default(),
+        mcp_socket_path,
+        session_dir,
+        agent_definitions,
+    );
+
+    println!(
+        "running workflow: {} (session: {})",
+        workflow.name, session_id
+    );
+    let result = engine.execute(&workflow, &dag, &spawner).await;
+
+    match result {
+        Ok(_ctx) => {
+            println!("workflow completed successfully.");
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("workflow failed: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/cli/src/spawner.rs
+++ b/crates/cli/src/spawner.rs
@@ -1,34 +1,51 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use fridi_agent::claude::ClaudeAgent;
+use fridi_agent::claude::{ClaudeAgent, ClaudeAgentConfig};
+use fridi_agent::definition::{AgentDefinition, TemplateContext, interpolate_prompt};
 use fridi_agent::traits::{Agent, AgentConfig};
 use fridi_core::engine::{AgentSpawner, StepResult, WorkflowContext};
 use fridi_core::orchestrator::Orchestrator;
 use fridi_core::schema::Step;
+use fridi_mcp::config::generate_mcp_config;
 use tokio::sync::Mutex;
-use tracing::{debug, info};
 
-/// Bridges the Engine to real Claude agent execution via the Orchestrator.
+/// Bridges the engine's `AgentSpawner` trait with the orchestrator and Claude agent.
 ///
-/// Implements `AgentSpawner` so the engine can drive workflow steps through
-/// actual Claude CLI sessions while the orchestrator handles bookkeeping.
-pub struct OrchestratorSpawner {
+/// For each step, it registers the agent with the orchestrator, writes an MCP config
+/// file, and runs the Claude CLI session to completion.
+pub(crate) struct OrchestratorSpawner {
     orchestrator: Arc<Mutex<Orchestrator>>,
-    claude_agent: ClaudeAgent,
+    agent_config: ClaudeAgentConfig,
     mcp_socket_path: String,
+    session_dir: PathBuf,
+    agent_definitions: Vec<AgentDefinition>,
 }
 
 impl OrchestratorSpawner {
-    pub fn new(
+    pub(crate) fn new(
         orchestrator: Arc<Mutex<Orchestrator>>,
-        claude_agent: ClaudeAgent,
+        agent_config: ClaudeAgentConfig,
         mcp_socket_path: String,
+        session_dir: PathBuf,
+        agent_definitions: Vec<AgentDefinition>,
     ) -> Self {
         Self {
             orchestrator,
-            claude_agent,
+            agent_config,
             mcp_socket_path,
+            session_dir,
+            agent_definitions,
         }
+    }
+
+    fn write_mcp_config(&self, agent_id: &str) -> Result<PathBuf, String> {
+        let config = generate_mcp_config(&self.mcp_socket_path, agent_id);
+        let config_path = self.session_dir.join(format!("mcp-{}.json", agent_id));
+        std::fs::create_dir_all(&self.session_dir).map_err(|e| e.to_string())?;
+        let json = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
+        std::fs::write(&config_path, json).map_err(|e| e.to_string())?;
+        Ok(config_path)
     }
 }
 
@@ -39,101 +56,76 @@ impl AgentSpawner for OrchestratorSpawner {
         context: &WorkflowContext,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<StepResult, String>> + Send>>
     {
-        let orchestrator = Arc::clone(&self.orchestrator);
-        let step = step.clone();
-        let agent_context = context.as_agent_context();
+        let orchestrator = self.orchestrator.clone();
+        let agent_type = step.agent.clone().unwrap_or_else(|| "claude".to_string());
+        let step_name = step.name.clone();
+        let step_clone = step.clone();
+        let ctx = context.as_agent_context();
+        let agent_config = self.agent_config.clone();
         let mcp_socket_path = self.mcp_socket_path.clone();
-        let claude_agent = self.claude_agent.clone();
+        let definitions = self.agent_definitions.clone();
+
+        // Register agent and write MCP config synchronously before spawning
+        let prepare_result: Result<(String, PathBuf), String> = (|| {
+            let mut orch = self.orchestrator.blocking_lock();
+            let agent_id = orch
+                .spawn_agent(&agent_type, serde_json::json!({"step": &step_name}), None)
+                .map_err(|e| e.to_string())?;
+
+            let mcp_config_path = self.write_mcp_config(&agent_id)?;
+            Ok((agent_id, mcp_config_path))
+        })();
 
         Box::pin(async move {
-            let role = step.agent.as_deref().unwrap_or("claude");
+            let (_agent_id, mcp_config_path) = prepare_result?;
 
-            // Register the agent in the orchestrator for session bookkeeping
-            let (agent_id, mcp_config_dir) = {
-                let mut orch = orchestrator.lock().await;
-                let id = orch
-                    .spawn_agent(role, serde_json::json!({}), None)
-                    .map_err(|e| format!("orchestrator spawn failed: {e}"))?;
-                let dir = orch.session_dir().join("mcp");
-                (id, dir)
+            let orch = orchestrator.lock().await;
+            let repo = orch.repo().to_string();
+            let session_id_str = orch.session().id.to_string();
+            let session_dir_str = orch.session_dir().to_string_lossy().to_string();
+            drop(orch);
+
+            let template_ctx = TemplateContext {
+                repo,
+                session_id: session_id_str,
+                session_dir: session_dir_str,
+                mcp_socket: mcp_socket_path,
             };
 
-            // Write MCP config so the agent can communicate back
-            let mcp_config = fridi_mcp::config::generate_mcp_config(&mcp_socket_path, &agent_id);
-            let mcp_config_path = mcp_config_dir.join(format!("{agent_id}.json"));
+            let agent_def = definitions.iter().find(|d| d.name == agent_type);
 
-            std::fs::create_dir_all(&mcp_config_dir)
-                .map_err(|e| format!("failed to create MCP config dir: {e}"))?;
-            std::fs::write(
-                &mcp_config_path,
-                serde_json::to_string_pretty(&mcp_config)
-                    .map_err(|e| format!("failed to serialize MCP config: {e}"))?,
-            )
-            .map_err(|e| format!("failed to write MCP config: {e}"))?;
+            let prompt = step_clone
+                .prompt
+                .clone()
+                .or_else(|| agent_def.map(|def| interpolate_prompt(&def.prompt, &template_ctx)));
 
-            debug!(agent_id = %agent_id, path = %mcp_config_path.display(), "wrote MCP config");
+            let args = step_clone.args.clone().or_else(|| {
+                agent_def
+                    .filter(|def| !def.default_args.is_empty())
+                    .map(|def| def.default_args.join(" "))
+            });
 
-            // Build the agent config from step fields
             let config = AgentConfig {
-                agent_type: "claude".into(),
-                skill: step.skill.clone(),
-                args: step.args.clone(),
-                prompt: step.prompt.clone(),
+                agent_type: agent_type.clone(),
+                skill: step_clone.skill.clone(),
+                args,
+                prompt,
                 working_dir: None,
                 env: Default::default(),
-                context: agent_context,
+                context: ctx,
                 session_id: None,
                 resume: false,
-                session_name: Some(format!("{}-{}", step.name, agent_id)),
-                mcp_config: Some(mcp_config_path.to_string_lossy().into_owned()),
+                session_name: Some(step_name.clone()),
+                mcp_config: Some(mcp_config_path.to_string_lossy().into()),
             };
 
-            // Spawn the Claude CLI process
-            let mut handle = claude_agent
-                .spawn(config)
-                .await
-                .map_err(|e| format!("agent spawn failed: {e}"))?;
+            let agent = ClaudeAgent::new(agent_config);
+            let mut handle = agent.spawn(config).await.map_err(|e| e.to_string())?;
 
-            // Record the claude session ID in the orchestrator
-            if let Some(session_id) = handle.session_id() {
-                let mut orch = orchestrator.lock().await;
-                if let Some(entry) = orch.session_mut().agents.get_mut(&agent_id) {
-                    entry.claude_session_id = Some(session_id.to_string());
-                    entry.status = "running".into();
-                }
-            }
-
-            info!(agent_id = %agent_id, step = %step.name, "agent spawned, waiting for completion");
-
-            // Wait for completion and collect output
-            let exit_code = handle
-                .wait()
-                .await
-                .map_err(|e| format!("agent wait failed: {e}"))?;
-
+            let exit_code = handle.wait().await.map_err(|e| e.to_string())?;
             let output = handle.collected_output();
 
-            // Update orchestrator status
-            {
-                let mut orch = orchestrator.lock().await;
-                if let Some(entry) = orch.session_mut().agents.get_mut(&agent_id) {
-                    entry.status = if exit_code == 0 {
-                        "completed".into()
-                    } else {
-                        format!("failed (exit {})", exit_code)
-                    };
-                }
-            }
-
-            // Try to parse structured JSON from the output
-            let structured_output = serde_json::from_str::<serde_json::Value>(&output).ok();
-
-            info!(
-                agent_id = %agent_id,
-                step = %step.name,
-                exit_code,
-                "agent completed"
-            );
+            let structured_output = serde_json::from_str(&output).ok();
 
             Ok(StepResult {
                 exit_code,
@@ -141,169 +133,5 @@ impl AgentSpawner for OrchestratorSpawner {
                 structured_output,
             })
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use fridi_agent::claude::ClaudeAgentConfig;
-    use fridi_core::orchestrator::AgentRoleConfig;
-    use fridi_core::session::{Session, SessionId, SessionStore};
-    use tempfile::TempDir;
-
-    use super::*;
-
-    fn test_role_configs() -> Vec<AgentRoleConfig> {
-        vec![AgentRoleConfig {
-            name: "claude".into(),
-            description: "Default Claude agent".into(),
-            prompt: "You are a helpful assistant".into(),
-            permissions: None,
-            allowed_tools: vec![],
-            spawnable_roles: vec![],
-            default_args: vec![],
-        }]
-    }
-
-    fn test_session() -> Session {
-        Session::new(
-            SessionId::new("test-wf"),
-            "test-wf".into(),
-            "test.yaml".into(),
-            Some("owner/repo".into()),
-        )
-    }
-
-    fn make_spawner(tmp: &TempDir) -> OrchestratorSpawner {
-        let store = SessionStore::new(tmp.path());
-        let session = test_session();
-        let session_dir = tmp.path().join(session.id.as_str());
-
-        let orchestrator = Orchestrator::new(
-            session,
-            store,
-            test_role_configs(),
-            "owner/repo",
-            session_dir,
-        );
-
-        let claude_agent = ClaudeAgent::new(ClaudeAgentConfig {
-            binary: "echo".into(),
-            default_args: vec![],
-        });
-
-        OrchestratorSpawner::new(
-            Arc::new(Mutex::new(orchestrator)),
-            claude_agent,
-            "/tmp/test.sock".into(),
-        )
-    }
-
-    #[test]
-    fn test_orchestrator_spawner_new() {
-        let tmp = TempDir::new().unwrap();
-        let spawner = make_spawner(&tmp);
-        assert_eq!(spawner.mcp_socket_path, "/tmp/test.sock");
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_spawn_step_builds_correct_config() {
-        let tmp = TempDir::new().unwrap();
-        let spawner = make_spawner(&tmp);
-
-        let step = Step {
-            name: "build".into(),
-            agent: Some("claude".into()),
-            skill: Some("coding".into()),
-            args: None,
-            prompt: Some("Build the project".into()),
-            depends_on: vec![],
-            condition: None,
-            for_each: None,
-            outputs: vec![],
-            on_failure: None,
-            retry: None,
-            step_type: None,
-            message: None,
-        };
-        let context = WorkflowContext::default();
-
-        let result = spawner.spawn_step(&step, &context).await;
-        assert!(result.is_ok(), "spawn_step failed: {:?}", result.err());
-
-        let result = result.unwrap();
-        assert_eq!(result.exit_code, 0);
-
-        // Verify the orchestrator tracked the agent
-        let orch = spawner.orchestrator.lock().await;
-        assert_eq!(orch.session().agents.len(), 1);
-        let entry = &orch.session().agents["claude-1"];
-        assert_eq!(entry.role, "claude");
-        assert_eq!(entry.status, "completed");
-        assert!(entry.claude_session_id.is_some());
-
-        // Verify MCP config was written under the session directory
-        let session_id = orch.session().id.as_str();
-        let mcp_path = tmp.path().join(format!("{session_id}/mcp/claude-1.json"));
-        assert!(mcp_path.exists(), "MCP config file should exist");
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_spawn_step_default_role() {
-        let tmp = TempDir::new().unwrap();
-        let spawner = make_spawner(&tmp);
-
-        let step = Step {
-            name: "default-role".into(),
-            agent: None,
-            skill: None,
-            args: None,
-            prompt: Some("Do something".into()),
-            depends_on: vec![],
-            condition: None,
-            for_each: None,
-            outputs: vec![],
-            on_failure: None,
-            retry: None,
-            step_type: None,
-            message: None,
-        };
-        let context = WorkflowContext::default();
-
-        let result = spawner.spawn_step(&step, &context).await;
-        assert!(result.is_ok());
-
-        let orch = spawner.orchestrator.lock().await;
-        let entry = &orch.session().agents["claude-1"];
-        assert_eq!(entry.role, "claude");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_spawn_step_unknown_role_fails() {
-        let tmp = TempDir::new().unwrap();
-        let spawner = make_spawner(&tmp);
-
-        let step = Step {
-            name: "bad-role".into(),
-            agent: Some("nonexistent".into()),
-            skill: None,
-            args: None,
-            prompt: None,
-            depends_on: vec![],
-            condition: None,
-            for_each: None,
-            outputs: vec![],
-            on_failure: None,
-            retry: None,
-            step_type: None,
-            message: None,
-        };
-        let context = WorkflowContext::default();
-
-        let result = spawner.spawn_step(&step, &context).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("orchestrator spawn failed"));
     }
 }


### PR DESCRIPTION
## Summary

- `fridi run <workflow.yaml>` CLI command with `--repo`, `--agents-dir`, `--sessions-dir` options
- Loads workflow, builds DAG, creates session, initializes orchestrator
- Subscribes to engine events for console status output
- Runs `Engine::execute()` with `OrchestratorSpawner` bridging to real Claude CLI sessions
- Clean exit codes (0 = success, 1 = failure)

This is the "turn the key" moment — fridi can now actually execute workflows.

```
$ fridi run workflows/pr-babysitter.yaml --repo xdustinface/fridi
```

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to run workflows with required workflow path plus optional repo, agents-dir, and sessions-dir options.
  * Workflow engine now runs asynchronously and emits lifecycle and step status events to the console.

* **Behavior Changes**
  * Agent definitions can be loaded from a provided agents directory (or omitted).
  * Session data and per-step agent config files are persisted under the sessions directory.

* **Chores**
  * CLI package integrated into the project packaging for easier invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->