### PR TITLE
feat(ui): add engine event bridge for live workflow status updates

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -1,12 +1,15 @@
 use std::path::PathBuf;
 
 use dioxus::prelude::*;
+use fridi_core::engine::EngineEvent;
 use fridi_core::session::{Session, SessionId, SessionStore};
 use fridi_core::window_state::WindowState;
+use tokio::sync::broadcast;
 
 use crate::components::session_creator::{SessionCreator, SessionSource};
 use crate::components::tab_bar::TabBar;
 use crate::components::workflow_view::WorkflowView;
+use crate::engine_bridge::use_engine_events;
 use crate::state::{self, TabInfo};
 use crate::styles;
 
@@ -65,6 +68,10 @@ pub(crate) fn App() -> Element {
     });
 
     let mut showing_creator = use_signal(|| false);
+
+    // Engine event bridge: receiver will be provided when an engine is wired up (#48)
+    let engine_rx: Signal<Option<broadcast::Receiver<EngineEvent>>> = use_signal(|| None);
+    let live_state = use_engine_events(engine_rx);
 
     // Helper to persist window state after tab changes
     let save_window_state = move |ws: &WindowState| {
@@ -209,7 +216,10 @@ pub(crate) fn App() -> Element {
             }
             div { class: "main-content",
                 if let Some(session) = active_session {
-                    WorkflowView { session }
+                    WorkflowView {
+                        session,
+                        live_state: Some(live_state.read().clone()),
+                    }
                 } else {
                     div { class: "empty-state",
                         "Click + to start a new session"

--- a/crates/ui/src/components/workflow_view.rs
+++ b/crates/ui/src/components/workflow_view.rs
@@ -5,6 +5,7 @@ use fridi_core::session::Session;
 
 use crate::components::step_card::StepCard;
 use crate::components::terminal_view::TerminalView;
+use crate::engine_bridge::LiveWorkflowState;
 
 /// Information about the currently selected step, used by the terminal view.
 struct SelectedStepInfo {
@@ -15,7 +16,7 @@ struct SelectedStepInfo {
 }
 
 #[component]
-pub(crate) fn WorkflowView(session: Session) -> Element {
+pub(crate) fn WorkflowView(session: Session, live_state: Option<LiveWorkflowState>) -> Element {
     let mut selected_step = use_signal(|| Option::<String>::None);
 
     let workflow =
@@ -40,20 +41,21 @@ pub(crate) fn WorkflowView(session: Session) -> Element {
     let selected_info: Option<SelectedStepInfo> = {
         let sel = selected_step.read();
         sel.as_ref().map(|name| {
+            let live_status = live_state
+                .as_ref()
+                .and_then(|ls| ls.step_statuses.get(name).cloned());
+
             let step_state = session
                 .steps
                 .values()
                 .filter(|ss| ss.step_name == *name)
                 .max_by_key(|ss| ss.attempt);
-            let (attempt, status_label, output) = match step_state {
-                Some(ss) => {
-                    let label = match &ss.status {
-                        StepStatus::Pending => "Pending".to_string(),
-                        StepStatus::Running => "Running".to_string(),
-                        StepStatus::Completed => "Completed".to_string(),
-                        StepStatus::Failed(reason) => format!("Failed: {reason}"),
-                        StepStatus::Skipped => "Skipped".to_string(),
-                    };
+
+            let effective_status = live_status.or_else(|| step_state.map(|ss| ss.status.clone()));
+
+            let (attempt, status_label, output) = match (&effective_status, step_state) {
+                (Some(status), Some(ss)) => {
+                    let label = format_status(status);
                     let output = ss
                         .output_summary
                         .as_ref()
@@ -61,7 +63,8 @@ pub(crate) fn WorkflowView(session: Session) -> Element {
                         .unwrap_or_default();
                     (ss.attempt, label, output)
                 }
-                None => (1, "Pending".to_string(), String::new()),
+                (Some(status), None) => (1, format_status(status), String::new()),
+                _ => (1, "Pending".to_string(), String::new()),
             };
             SelectedStepInfo {
                 name: name.clone(),
@@ -98,10 +101,15 @@ pub(crate) fn WorkflowView(session: Session) -> Element {
                 div { class: "steps-list",
                     for step in &steps {
                         {
-                            let status = session.steps.values()
-                                .filter(|ss| ss.step_name == step.name)
-                                .max_by_key(|ss| ss.attempt)
-                                .map(|ss| ss.status.clone());
+                            let status = live_state
+                                .as_ref()
+                                .and_then(|ls| ls.step_statuses.get(&step.name).cloned())
+                                .or_else(|| {
+                                    session.steps.values()
+                                        .filter(|ss| ss.step_name == step.name)
+                                        .max_by_key(|ss| ss.attempt)
+                                        .map(|ss| ss.status.clone())
+                                });
                             let is_selected = selected_step.read().as_deref() == Some(&step.name);
                             rsx! {
                                 StepCard {
@@ -137,10 +145,39 @@ pub(crate) fn WorkflowView(session: Session) -> Element {
         }
     });
 
+    let notifications: Vec<String> = live_state
+        .as_ref()
+        .map(|ls| ls.notifications.clone())
+        .unwrap_or_default();
+
     rsx! {
         crate::components::split_pane::SplitPane {
             top: dag_view,
             bottom: terminal,
+        }
+        if !notifications.is_empty() {
+            NotificationBar { notifications }
+        }
+    }
+}
+
+fn format_status(status: &StepStatus) -> String {
+    match status {
+        StepStatus::Pending => "Pending".to_string(),
+        StepStatus::Running => "Running".to_string(),
+        StepStatus::Completed => "Completed".to_string(),
+        StepStatus::Failed(reason) => format!("Failed: {reason}"),
+        StepStatus::Skipped => "Skipped".to_string(),
+    }
+}
+
+#[component]
+fn NotificationBar(notifications: Vec<String>) -> Element {
+    rsx! {
+        div { class: "notification-bar",
+            for (i, msg) in notifications.iter().enumerate() {
+                div { key: "{i}", class: "notification-item", "{msg}" }
+            }
         }
     }
 }

--- a/crates/ui/src/engine_bridge.rs
+++ b/crates/ui/src/engine_bridge.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use dioxus::prelude::*;
+use fridi_core::engine::{EngineEvent, StepStatus};
+use fridi_core::session::SessionStatus;
+use tokio::sync::broadcast;
+
+/// Live workflow state updated by engine events
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct LiveWorkflowState {
+    pub(crate) step_statuses: HashMap<String, StepStatus>,
+    pub(crate) workflow_status: Option<SessionStatus>,
+    pub(crate) notifications: Vec<String>,
+}
+
+/// Dioxus hook that subscribes to engine events and produces live workflow state.
+///
+/// The receiver signal should contain an `Option<broadcast::Receiver<EngineEvent>>`.
+/// On first run the receiver is taken (via `Option::take`) so it can only be consumed once.
+pub(crate) fn use_engine_events(
+    mut rx: Signal<Option<broadcast::Receiver<EngineEvent>>>,
+) -> Signal<LiveWorkflowState> {
+    let mut state = use_signal(LiveWorkflowState::default);
+
+    use_coroutine(move |_: UnboundedReceiver<()>| async move {
+        let Some(mut receiver) = rx.write().take() else {
+            return;
+        };
+        while let Ok(event) = receiver.recv().await {
+            match event {
+                EngineEvent::StepStatusChanged { step_name, status } => {
+                    state.write().step_statuses.insert(step_name, status);
+                }
+                EngineEvent::WorkflowStarted { .. } => {
+                    let mut s = state.write();
+                    s.workflow_status = Some(SessionStatus::Running);
+                    s.step_statuses.clear();
+                }
+                EngineEvent::WorkflowCompleted { .. } => {
+                    state.write().workflow_status = Some(SessionStatus::Completed);
+                }
+                EngineEvent::WorkflowFailed { reason, .. } => {
+                    let mut s = state.write();
+                    s.workflow_status = Some(SessionStatus::Failed);
+                    s.notifications.push(format!("Failed: {reason}"));
+                }
+                EngineEvent::NotificationRequired { step_name, message } => {
+                    state
+                        .write()
+                        .notifications
+                        .push(format!("[{step_name}] {message}"));
+                }
+            }
+        }
+    });
+
+    state
+}

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod components;
+mod engine_bridge;
 mod state;
 mod styles;
 

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -650,4 +650,27 @@ body {
     word-break: break-all;
     margin: 0;
 }
+
+.notification-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    max-height: 120px;
+    overflow-y: auto;
+    background-color: #1c2128;
+    border-top: 1px solid #30363d;
+    padding: 8px 16px;
+    z-index: 100;
+}
+
+.notification-item {
+    padding: 4px 8px;
+    margin-bottom: 4px;
+    font-size: 12px;
+    color: #f0883e;
+    background-color: rgba(240, 136, 62, 0.1);
+    border-left: 3px solid #f0883e;
+    border-radius: 3px;
+}
 "#;


### PR DESCRIPTION
## Summary

- New `engine_bridge.rs` with `LiveWorkflowState` and `use_engine_events` coroutine hook
- Bridges `EngineEvent` broadcast to Dioxus signals for real-time UI updates
- `WorkflowView` prefers live step statuses over persisted session data
- Notification bar at bottom for workflow alerts
- Receiver signal wired up as `None` (issue #48 will connect it to actual execution)

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time step status updates in the workflow view, synchronized with engine events.
  * Workflow status notifications now display in a dedicated notification bar at the bottom of the screen.
  * Live workflow execution progress is reflected in the UI as the workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->