### PR TITLE
fix(agent): wrap PTY spawn and wait in spawn_blocking for async safety

### DIFF
--- a/crates/agent/src/claude.rs
+++ b/crates/agent/src/claude.rs
@@ -106,7 +106,7 @@ impl Agent for ClaudeAgent {
 
         info!("spawning Claude CLI: {:?}", cmd);
 
-        let pty = PtyProcess::spawn(cmd)?;
+        let pty = PtyProcess::spawn_async(cmd).await?;
         Ok(Box::new(ClaudeAgentHandle { pty, session_id }))
     }
 }

--- a/crates/agent/src/pty.rs
+++ b/crates/agent/src/pty.rs
@@ -18,6 +18,13 @@ pub struct PtyProcess {
 }
 
 impl PtyProcess {
+    /// Async-safe wrapper that runs the blocking PTY spawn on a dedicated thread.
+    pub async fn spawn_async(cmd: CommandBuilder) -> Result<Self, AgentError> {
+        tokio::task::spawn_blocking(move || Self::spawn(cmd))
+            .await
+            .map_err(|e| AgentError::SpawnError(format!("spawn task failed: {e}")))?
+    }
+
     pub fn spawn(cmd: CommandBuilder) -> Result<Self, AgentError> {
         let pty_system = NativePtySystem::default();
         let pair = pty_system
@@ -99,9 +106,14 @@ impl PtyProcess {
     }
 
     pub async fn wait(&mut self) -> Result<i32, AgentError> {
-        let mut child = self.child.lock().await;
-        let status = tokio::task::block_in_place(|| child.wait())
-            .map_err(|e| AgentError::ExecutionError(format!("failed to wait: {e}")))?;
+        let child = self.child.clone();
+        let status = tokio::task::spawn_blocking(move || {
+            let mut child = child.blocking_lock();
+            child.wait()
+        })
+        .await
+        .map_err(|e| AgentError::ExecutionError(format!("wait task failed: {e}")))?
+        .map_err(|e| AgentError::ExecutionError(format!("failed to wait: {e}")))?;
 
         self.running.store(false, Ordering::Relaxed);
 


### PR DESCRIPTION
## Summary

- Add `PtyProcess::spawn_async()` wrapping synchronous spawn in `spawn_blocking`
- Change `PtyProcess::wait()` to use `spawn_blocking` instead of `block_in_place`
- `ClaudeAgent::spawn()` now calls `spawn_async()` — safe in both single/multi-threaded tokio runtimes
- Fixes: "Cannot block the current thread from within a runtime" panic when running `fridi run`

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized asynchronous process management for improved efficiency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->