### PR TITLE
feat(ui): wire session creation modes to actual agent execution

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -167,7 +167,7 @@ pub(crate) fn App() -> Element {
                 format!("issue-{number}"),
                 format!("Issue #{number}: {title}"),
             ),
-            SessionSource::PR { number, title } => {
+            SessionSource::PR { number, title, .. } => {
                 (format!("pr-{number}"), format!("PR #{number}: {title}"))
             }
             SessionSource::Prompt { text } => {
@@ -186,6 +186,9 @@ pub(crate) fn App() -> Element {
 
         let session_id = SessionId::new(&workflow_name);
         let repo = repo_for_create.clone();
+        let repo_str = repo.clone().unwrap_or_default();
+
+        let workflow = crate::workflow_runner::workflow_from_source(&source, &repo_str);
 
         let session = Session::new(
             session_id.clone(),
@@ -200,28 +203,23 @@ pub(crate) fn App() -> Element {
             return;
         }
 
-        // Find the first workflow to execute
-        let workflow_opt = workflows.read().first().map(|(wf, _)| wf.clone());
-
         // Start workflow execution in a background task
-        if let Some(workflow) = workflow_opt {
-            let runner_clone = runner.read().clone();
-            let session_clone = session.clone();
-            let store_clone = current_store;
-            spawn(async move {
-                match runner_clone
-                    .start(workflow, session_clone, store_clone)
-                    .await
-                {
-                    Ok(rx) => {
-                        engine_rx.set(Some(rx));
-                    }
-                    Err(e) => {
-                        eprintln!("failed to start workflow execution: {e}");
-                    }
+        let runner_clone = runner.read().clone();
+        let session_clone = session.clone();
+        let store_clone = current_store;
+        spawn(async move {
+            match runner_clone
+                .start(workflow, session_clone, store_clone)
+                .await
+            {
+                Ok(rx) => {
+                    engine_rx.set(Some(rx));
                 }
-            });
-        }
+                Err(e) => {
+                    eprintln!("failed to start workflow execution: {e}");
+                }
+            }
+        });
 
         let tab = TabInfo {
             session_id: session_id.clone(),

--- a/crates/ui/src/components/session_creator.rs
+++ b/crates/ui/src/components/session_creator.rs
@@ -19,9 +19,18 @@ enum LoadState<T: Clone + PartialEq> {
 /// Describes which source triggered session creation.
 #[derive(Clone, Debug)]
 pub(crate) enum SessionSource {
-    Issue { number: u64, title: String },
-    PR { number: u64, title: String },
-    Prompt { text: String },
+    Issue {
+        number: u64,
+        title: String,
+    },
+    PR {
+        number: u64,
+        title: String,
+        head_ref: String,
+    },
+    Prompt {
+        text: String,
+    },
 }
 
 #[component]
@@ -248,6 +257,7 @@ pub(crate) fn SessionCreator(
                                                 {
                                                     let num = pr.number;
                                                     let title = pr.title.clone();
+                                                    let head_ref = pr.head_ref_name.clone();
                                                     rsx! {
                                                         div {
                                                             key: "pr-{num}",
@@ -256,6 +266,7 @@ pub(crate) fn SessionCreator(
                                                                 on_create.call(SessionSource::PR {
                                                                     number: num,
                                                                     title: title.clone(),
+                                                                    head_ref: head_ref.clone(),
                                                                 });
                                                             },
                                                             span { class: "picker-item-number", "#{num}" }

--- a/crates/ui/src/workflow_runner.rs
+++ b/crates/ui/src/workflow_runner.rs
@@ -7,10 +7,12 @@ use fridi_cli::spawner::OrchestratorSpawner;
 use fridi_core::dag::WorkflowDag;
 use fridi_core::engine::{Engine, EngineEvent};
 use fridi_core::orchestrator::Orchestrator;
-use fridi_core::schema::Workflow;
+use fridi_core::schema::{Step, Workflow, WorkflowConfig};
 use fridi_core::session::{Session, SessionStore};
 use tokio::sync::{Mutex, broadcast};
 use tracing::{error, info};
+
+use crate::components::session_creator::SessionSource;
 
 /// Encapsulates starting a workflow execution in a background tokio task.
 #[derive(Clone)]
@@ -85,5 +87,85 @@ impl WorkflowRunner {
         });
 
         Ok(event_rx)
+    }
+}
+
+/// Build a single-step workflow from the user's session source.
+pub(crate) fn workflow_from_source(source: &SessionSource, repo: &str) -> Workflow {
+    let default_config = || WorkflowConfig {
+        repo: Some(repo.into()),
+        ..Default::default()
+    };
+
+    match source {
+        SessionSource::Prompt { text } => Workflow {
+            name: "prompt".into(),
+            description: Some("User prompt".into()),
+            config: default_config(),
+            triggers: vec![],
+            notifications: Default::default(),
+            steps: vec![Step {
+                name: "execute".into(),
+                agent: Some("claude".into()),
+                prompt: Some(text.clone()),
+                ..default_step()
+            }],
+        },
+        SessionSource::Issue { number, title } => Workflow {
+            name: format!("issue-{number}"),
+            description: Some(format!("Issue #{number}: {title}")),
+            config: default_config(),
+            triggers: vec![],
+            notifications: Default::default(),
+            steps: vec![Step {
+                name: "work-on-issue".into(),
+                agent: Some("claude".into()),
+                prompt: Some(format!(
+                    "Work on issue #{number} in repo {repo}:\n\n\
+                     Title: {title}\n\n\
+                     Analyze the issue, plan the implementation, and execute it."
+                )),
+                ..default_step()
+            }],
+        },
+        SessionSource::PR {
+            number,
+            title,
+            head_ref,
+        } => Workflow {
+            name: format!("pr-{number}"),
+            description: Some(format!("PR #{number}: {title}")),
+            config: default_config(),
+            triggers: vec![],
+            notifications: Default::default(),
+            steps: vec![Step {
+                name: "work-on-pr".into(),
+                agent: Some("claude".into()),
+                prompt: Some(format!(
+                    "Work on PR #{number} ({title}) in repo {repo}:\n\n\
+                     Branch: {head_ref}\n\n\
+                     Review the PR, fix any issues, and ensure CI passes."
+                )),
+                ..default_step()
+            }],
+        },
+    }
+}
+
+fn default_step() -> Step {
+    Step {
+        name: String::new(),
+        agent: None,
+        skill: None,
+        args: None,
+        prompt: None,
+        depends_on: vec![],
+        condition: None,
+        for_each: None,
+        outputs: vec![],
+        on_failure: None,
+        retry: None,
+        step_type: None,
+        message: None,
     }
 }


### PR DESCRIPTION
## Summary

- `workflow_from_source()` creates dynamic single-step workflows from user input
- Prompt mode: passes user text directly as the Claude prompt
- Issue mode: generates prompt with issue number, title, repo context
- PR mode: generates prompt with PR number, title, branch name
- No more silent fallback to first YAML workflow

Closes #76