### PR TITLE
fix(ui): inject CSS via `with_custom_head` to prevent Style re-render warnings

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -13,7 +13,6 @@ use crate::components::tab_bar::TabBar;
 use crate::components::workflow_view::WorkflowView;
 use crate::engine_bridge::use_engine_events;
 use crate::state::{self, TabInfo};
-use crate::styles;
 use crate::workflow_runner::WorkflowRunner;
 
 const SESSIONS_DIR: &str = ".fridi/sessions";
@@ -259,7 +258,6 @@ pub(crate) fn App() -> Element {
     };
 
     rsx! {
-        document::Style { {styles::APP_CSS} }
         div { class: "app-layout",
             TabBar {
                 tabs: tabs.read().clone(),

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -13,7 +13,8 @@ fn main() {
     dioxus::LaunchBuilder::desktop()
         .with_cfg(
             dioxus::desktop::Config::new()
-                .with_window(dioxus::desktop::WindowBuilder::new().with_title("fridi")),
+                .with_window(dioxus::desktop::WindowBuilder::new().with_title("fridi"))
+                .with_custom_head(format!("<style>{}</style>", styles::APP_CSS)),
         )
         .with_context(app::DetectedRepo(repo))
         .launch(app::App);


### PR DESCRIPTION
## Summary

- Move CSS injection from `document::Style` RSX element to `dioxus::desktop::Config::with_custom_head()` in `main.rs`
- CSS is now injected once as a `<style>` tag in the HTML head at launch, bypassing reactive rendering entirely
- Eliminates `WARN dioxus_document::elements: Changing the props of Style {} is not supported` spam

Closes #82