### PR TITLE
fix(ui): subscribe to engine events before starting execution to prevent race

### DIFF
--- a/crates/ui/src/workflow_runner.rs
+++ b/crates/ui/src/workflow_runner.rs
@@ -61,9 +61,7 @@ impl WorkflowRunner {
         )?;
         let orchestrator = Arc::new(Mutex::new(orchestrator));
 
-        let (engine, _initial_rx) = Engine::new();
-        // Subscribe before spawning execution so no events are lost
-        let event_rx = engine.subscribe();
+        let (engine, event_rx) = Engine::new();
 
         let agent_definitions = if self.agents_dir.exists() {
             load_agent_definitions(&self.agents_dir).unwrap_or_default()


### PR DESCRIPTION
## Summary

- Subscribe to the engine broadcast channel BEFORE spawning execution, ensuring no events are lost
- Fix `use_engine_events` hook to poll for the receiver signal instead of reading it once at mount (when it's still `None`)
- Step cards now update Pending → Running → Completed in real-time, terminal shows live PTY output

Closes #102