### PR TITLE
fix(ui): wire engine event sender into spawner so PTY output reaches UI

### DIFF
--- a/crates/cli/src/spawner.rs
+++ b/crates/cli/src/spawner.rs
@@ -41,8 +41,7 @@ impl OrchestratorSpawner {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn with_event_sender(mut self, tx: broadcast::Sender<EngineEvent>) -> Self {
+    pub fn with_event_sender(mut self, tx: broadcast::Sender<EngineEvent>) -> Self {
         self.event_tx = Some(tx);
         self
     }

--- a/crates/ui/src/workflow_runner.rs
+++ b/crates/ui/src/workflow_runner.rs
@@ -76,7 +76,8 @@ impl WorkflowRunner {
             mcp_socket_path,
             session_dir,
             agent_definitions,
-        );
+        )
+        .with_event_sender(engine.event_sender());
 
         let workflow_name = workflow.name.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

- Chain `.with_event_sender(engine.event_sender())` onto `OrchestratorSpawner::new()` in `workflow_runner.rs`
- Without this, `event_tx` was `None`, the output forwarder never spawned, and no PTY output or step status events reached the UI
- Also make `with_event_sender` public since it's called cross-crate

Closes #102