### PR TITLE
fix(ui): auto-focus prompt text field in session creator

### DIFF
--- a/crates/ui/src/components/session_creator.rs
+++ b/crates/ui/src/components/session_creator.rs
@@ -297,6 +297,11 @@ pub(crate) fn SessionCreator(
                             placeholder: "Describe the task...",
                             value: "{prompt_text}",
                             oninput: move |evt| prompt_text.set(evt.value()),
+                            onmounted: move |evt: MountedEvent| {
+                                spawn(async move {
+                                    let _ = evt.set_focus(true).await;
+                                });
+                            },
                         }
                         button {
                             class: "creator-submit",


### PR DESCRIPTION
## Summary

- Add `onmounted` handler to the prompt textarea that calls `set_focus(true)` when mounted
- Cursor is now immediately ready for typing when "New by Prompt" session creator opens

Closes #121