### PR TITLE
feat(cli): add `fridi backlog` command to append to backlog

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
+use fridi_core::backlog::Backlog;
 
 mod run;
 mod spawner;
@@ -31,6 +32,12 @@ enum Commands {
         #[arg(long, default_value = ".fridi/sessions")]
         sessions_dir: PathBuf,
     },
+
+    /// Append an item to the local backlog
+    Backlog {
+        /// The backlog item text (supports inline #tags and !/!! priority)
+        text: String,
+    },
 }
 
 #[tokio::main]
@@ -51,5 +58,13 @@ async fn main() -> anyhow::Result<()> {
             agents_dir,
             sessions_dir,
         } => run::execute(workflow, repo, agents_dir, sessions_dir).await,
+        Commands::Backlog { text } => {
+            let path = PathBuf::from(".fridi/backlog.md");
+            let mut backlog = Backlog::load(&path)?;
+            backlog.add(&text, None);
+            backlog.save()?;
+            println!("Added to backlog: {text}");
+            Ok(())
+        }
     }
 }

--- a/crates/core/src/backlog.rs
+++ b/crates/core/src/backlog.rs
@@ -55,7 +55,7 @@ impl BacklogItem {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum BacklogError {
+pub enum BacklogError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("invalid item index: {0}")]
@@ -64,7 +64,7 @@ pub(crate) enum BacklogError {
 
 /// Persistent backlog stored as a markdown file.
 #[derive(Debug)]
-pub(crate) struct Backlog {
+pub struct Backlog {
     path: PathBuf,
     items: Vec<BacklogItem>,
 }
@@ -72,7 +72,7 @@ pub(crate) struct Backlog {
 impl Backlog {
     /// Load a backlog from the given file path. Returns an empty backlog if the
     /// file does not exist.
-    pub(crate) fn load(path: impl Into<PathBuf>) -> Result<Self, BacklogError> {
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self, BacklogError> {
         let path = path.into();
         if !path.exists() {
             return Ok(Self {
@@ -87,7 +87,7 @@ impl Backlog {
     }
 
     /// Write the backlog back to disk, creating parent directories if needed.
-    pub(crate) fn save(&self) -> Result<(), BacklogError> {
+    pub fn save(&self) -> Result<(), BacklogError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -104,7 +104,7 @@ impl Backlog {
     }
 
     /// Add a new item, parsing tags and priority from the text.
-    pub(crate) fn add(&mut self, text: &str, context: Option<&str>) {
+    pub fn add(&mut self, text: &str, context: Option<&str>) {
         let (priority, rest) = parse_priority(text);
         let tags = extract_tags(rest);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-pub(crate) mod backlog;
+pub mod backlog;
 pub mod dag;
 pub mod engine;
 pub mod github;


### PR DESCRIPTION
## Summary

- Add `fridi backlog "text #tag"` CLI subcommand that appends to `.fridi/backlog.md`
- Parses inline `#tags` and `!`/`!!` priority markers via the existing `Backlog::add()` method
- Widen `Backlog` visibility from `pub(crate)` to `pub` for cross-crate access

Closes #105