### PR TITLE
fix(ui): ensure xterm replays all buffered output on tab switch re-mount

### DIFF
--- a/crates/ui/src/components/terminal_view.rs
+++ b/crates/ui/src/components/terminal_view.rs
@@ -96,6 +96,80 @@ pub(crate) fn TerminalView(
     // Whether the xterm instance for the current terminal_id has been created.
     let mut terminal_ready = use_signal(|| false);
 
+    // Spawns a resize event channel for the given terminal. The JS calls
+    // `dioxus.send()` on every xterm resize (and once immediately with the
+    // initial size). Each new xterm instance needs its own channel.
+    let resize_key = format!("{}:{}", session_id, step_name);
+    let start_resize_channel = {
+        let resize_key = resize_key.clone();
+        move |tid: String| {
+            let step = resize_key.clone();
+            spawn(async move {
+                let js = format!(
+                    r#"
+                    var t = window.fridiTerminals['{tid}'];
+                    if (t) {{
+                        dioxus.send({{ cols: t.cols, rows: t.rows }});
+                        var resizeTimer = null;
+                        t.onResize(function(size) {{
+                            if (resizeTimer) clearTimeout(resizeTimer);
+                            resizeTimer = setTimeout(function() {{
+                                dioxus.send({{ cols: size.cols, rows: size.rows }});
+                            }}, 150);
+                        }});
+                    }}
+                    "#
+                );
+
+                let mut eval = document::eval(&js);
+
+                tracing::info!("PTY resize channel established for step {}", step);
+
+                loop {
+                    match eval.recv::<serde_json::Value>().await {
+                        Ok(val) => {
+                            if let (Some(cols), Some(rows)) = (
+                                val.get("cols").and_then(|v| v.as_u64()),
+                                val.get("rows").and_then(|v| v.as_u64()),
+                            ) {
+                                let cols = cols as u16;
+                                let rows = rows as u16;
+                                tracing::info!(
+                                    "PTY resize event: {}x{} for step {}",
+                                    cols,
+                                    rows,
+                                    step
+                                );
+                                if let Some(resizer) = pty::get_resizer(&step) {
+                                    resizer.resize(cols, rows);
+                                } else {
+                                    let mut retries = 0;
+                                    while pty::get_resizer(&step).is_none() && retries < 30 {
+                                        tokio::time::sleep(std::time::Duration::from_millis(100))
+                                            .await;
+                                        retries += 1;
+                                    }
+                                    if let Some(resizer) = pty::get_resizer(&step) {
+                                        resizer.resize(cols, rows);
+                                    } else {
+                                        tracing::warn!(
+                                            "PTY resizer not found after retries for step {}",
+                                            step
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("PTY resize channel closed for step {}: {}", step, e);
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+    };
+
     // When the step changes, reset tracking state, destroy old terminal, and
     // create a new xterm instance. Dioxus reuses the DOM div so `onmounted`
     // won't fire again — we must re-initialize xterm ourselves.
@@ -108,6 +182,8 @@ pub(crate) fn TerminalView(
 
         if !old_id.is_empty() {
             let init_js = xterm_init_js(&new_id);
+            let tid = new_id.clone();
+            let start_resize = start_resize_channel.clone();
             spawn(async move {
                 // Dispose the old terminal first.
                 let dispose_js = format!(
@@ -122,100 +198,26 @@ pub(crate) fn TerminalView(
                 // Initialize xterm on the reused DOM element.
                 let _ = document::eval(&init_js).await;
                 terminal_ready.set(true);
+                start_resize(tid);
             });
         }
     }
 
     // Initialize xterm.js when the container div is first mounted in the DOM.
     let tid_for_mount = terminal_id.read().clone();
+    let start_resize_on_mount = start_resize_channel.clone();
     let on_mounted = move |_evt: MountedEvent| {
         written_len.set(0);
         terminal_ready.set(false);
         let js = xterm_init_js(&tid_for_mount);
+        let tid = tid_for_mount.clone();
+        let start_resize = start_resize_on_mount.clone();
         spawn(async move {
             let _ = document::eval(&js).await;
             terminal_ready.set(true);
+            start_resize(tid);
         });
     };
-
-    // Event-driven PTY resize via `dioxus.send()`/`eval.recv()`.
-    let resize_key = format!("{}:{}", session_id, step_name);
-    let resize_tid = terminal_id.read().clone();
-    use_coroutine(move |_: UnboundedReceiver<()>| {
-        let step = resize_key.clone();
-        let tid = resize_tid.clone();
-        async move {
-            // Wait for the terminal to be created in JS.
-            loop {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                let check = format!("return window.fridiTerminals['{}'] ? true : false;", tid);
-                if let Ok(val) = document::eval(&check).await {
-                    if val == true {
-                        break;
-                    }
-                }
-            }
-
-            // Set up the resize event channel. The JS calls `dioxus.send()` on
-            // every xterm resize (and once immediately with the initial size).
-            let js = format!(
-                r#"
-                var t = window.fridiTerminals['{tid}'];
-                if (t) {{
-                    dioxus.send({{ cols: t.cols, rows: t.rows }});
-                    var resizeTimer = null;
-                    t.onResize(function(size) {{
-                        if (resizeTimer) clearTimeout(resizeTimer);
-                        resizeTimer = setTimeout(function() {{
-                            dioxus.send({{ cols: size.cols, rows: size.rows }});
-                        }}, 150);
-                    }});
-                }}
-                "#
-            );
-
-            let mut eval = document::eval(&js);
-
-            tracing::info!("PTY resize channel established for step {}", step);
-
-            loop {
-                match eval.recv::<serde_json::Value>().await {
-                    Ok(val) => {
-                        if let (Some(cols), Some(rows)) = (
-                            val.get("cols").and_then(|v| v.as_u64()),
-                            val.get("rows").and_then(|v| v.as_u64()),
-                        ) {
-                            let cols = cols as u16;
-                            let rows = rows as u16;
-                            tracing::info!("PTY resize event: {}x{} for step {}", cols, rows, step);
-                            if let Some(resizer) = pty::get_resizer(&step) {
-                                resizer.resize(cols, rows);
-                            } else {
-                                // Resizer may not be registered yet; retry with backoff.
-                                let mut retries = 0;
-                                while pty::get_resizer(&step).is_none() && retries < 30 {
-                                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                                    retries += 1;
-                                }
-                                if let Some(resizer) = pty::get_resizer(&step) {
-                                    resizer.resize(cols, rows);
-                                } else {
-                                    tracing::warn!(
-                                        "PTY resizer not found after retries for step {}",
-                                        step
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!("PTY resize channel closed for step {}: {}", step, e);
-                        break;
-                    }
-                }
-            }
-        }
-    });
 
     // Write new output data to the xterm instance (only the delta since last write).
     let current_len = output.len();


### PR DESCRIPTION
## Summary

- Reset `written_len` and `terminal_ready` in `onmounted` to force full output replay
- Dispose stale xterm instance in JS init before creating fresh one (fixes race with async cleanup)
- Root cause: Dioxus `use_signal` persists across unmount/re-mount, so old `written_len` prevented replay

Closes #150