### PR TITLE
feat(ui): add Ready button to remove needs-human label from PRs on Home dashboard

### DIFF
--- a/crates/core/src/github.rs
+++ b/crates/core/src/github.rs
@@ -27,6 +27,8 @@ pub struct GitHubPR {
     pub updated_at: String,
     #[serde(rename = "statusCheckRollup", default)]
     pub status_check_rollup: Vec<StatusCheck>,
+    #[serde(default)]
+    pub labels: Vec<GitHubLabel>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -184,7 +186,7 @@ pub fn fetch_prs(repo: &str) -> Result<Vec<GitHubPR>, GitHubError> {
             "--state",
             "open",
             "--json",
-            "number,title,headRefName,updatedAt,statusCheckRollup",
+            "number,title,headRefName,updatedAt,statusCheckRollup,labels",
             "--limit",
             "50",
         ])
@@ -198,6 +200,29 @@ pub fn fetch_prs(repo: &str) -> Result<Vec<GitHubPR>, GitHubError> {
 
     let prs: Vec<GitHubPR> = serde_json::from_slice(&output.stdout)?;
     Ok(prs)
+}
+
+/// Remove a label from a pull request using the `gh` CLI.
+pub fn remove_pr_label(repo: &str, pr_number: u64, label: &str) -> Result<(), GitHubError> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "edit",
+            &pr_number.to_string(),
+            "--repo",
+            repo,
+            "--remove-label",
+            label,
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(GitHubError::NonZero {
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+
+    Ok(())
 }
 
 /// Select the highest priority open issue. Prioritizes by label name containing

--- a/crates/core/src/project_overview.rs
+++ b/crates/core/src/project_overview.rs
@@ -32,6 +32,7 @@ pub struct PrSummary {
     pub branch: String,
     pub ci_status: CiStatus,
     pub updated_at: String,
+    pub labels: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +85,7 @@ fn fetch_pr_summaries(repo: &str) -> Result<Vec<PrSummary>, GitHubError> {
             branch: pr.head_ref_name,
             ci_status: CiStatus::from_checks(&pr.status_check_rollup),
             updated_at: pr.updated_at,
+            labels: pr.labels.into_iter().map(|l| l.name).collect(),
         })
         .collect())
 }

--- a/crates/ui/src/components/home_dashboard.rs
+++ b/crates/ui/src/components/home_dashboard.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use dioxus::prelude::*;
@@ -87,6 +88,7 @@ pub(crate) fn HomeDashboard(
 ) -> Element {
     let mut state = use_signal(|| FetchState::Loading);
     let mut pick_state = use_signal(|| PickState::Idle);
+    let mut removing_labels: Signal<HashSet<u64>> = use_signal(HashSet::new);
     let repo_clone = repo.clone();
     let work_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
@@ -200,12 +202,46 @@ pub(crate) fn HomeDashboard(
                         count: overview.open_prs.len(),
                         children: rsx! {
                             for pr in &overview.open_prs {
-                                div { class: "dashboard-row", key: "pr-{pr.number}",
-                                    span { class: "dashboard-number", "#{pr.number}" }
-                                    span { class: "dashboard-title", "{pr.title}" }
-                                    span { class: "dashboard-branch", "{pr.branch}" }
-                                    span { class: ci_badge_class(&pr.ci_status), "{ci_badge_label(&pr.ci_status)}" }
-                                    span { class: "dashboard-time", "{relative_time(&pr.updated_at)}" }
+                                {
+                                    let needs_human = pr.labels.iter().any(|l| l == "needs-human");
+                                    let pr_number = pr.number;
+                                    let is_removing = removing_labels.read().contains(&pr_number);
+                                    rsx! {
+                                        div { class: "dashboard-row", key: "pr-{pr_number}",
+                                            span { class: "dashboard-number", "#{pr.number}" }
+                                            span { class: "dashboard-title", "{pr.title}" }
+                                            span { class: "dashboard-branch", "{pr.branch}" }
+                                            span { class: ci_badge_class(&pr.ci_status), "{ci_badge_label(&pr.ci_status)}" }
+                                            if needs_human {
+                                                button {
+                                                    class: "dashboard-ready-btn",
+                                                    disabled: is_removing || !has_repo,
+                                                    onclick: {
+                                                        let repo_str = repo.clone().unwrap_or_default();
+                                                        move |_| {
+                                                            let r = repo_str.clone();
+                                                            removing_labels.write().insert(pr_number);
+                                                            spawn(async move {
+                                                                let result = tokio::task::spawn_blocking(move || {
+                                                                    github::remove_pr_label(&r, pr_number, "needs-human")
+                                                                }).await;
+                                                                removing_labels.write().remove(&pr_number);
+                                                                if let Ok(Ok(())) = result {
+                                                                    if let FetchState::Loaded(ref mut data) = *state.write() {
+                                                                        if let Some(pr) = data.open_prs.iter_mut().find(|p| p.number == pr_number) {
+                                                                            pr.labels.retain(|l| l != "needs-human");
+                                                                        }
+                                                                    }
+                                                                }
+                                                            });
+                                                        }
+                                                    },
+                                                    if is_removing { "Removing..." } else { "Ready" }
+                                                }
+                                            }
+                                            span { class: "dashboard-time", "{relative_time(&pr.updated_at)}" }
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -892,6 +892,29 @@ body {
     display: none;
 }
 
+.dashboard-ready-btn {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px var(--space-3);
+    background-color: var(--accent-subtle);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-sm);
+    color: var(--accent-hover);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.dashboard-ready-btn:hover:not(:disabled) {
+    background-color: var(--accent);
+    color: var(--text-primary);
+}
+
+.dashboard-ready-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
 .dashboard-empty {
     padding: var(--space-4);
     text-align: center;


### PR DESCRIPTION
## Summary

- PRs with `needs-human` label show a "Ready" button in the Home dashboard
- One click removes the label via `gh pr edit --remove-label`, signaling the coordinator to proceed
- Added labels to PR data model (`PrSummary.labels`) and `remove_pr_label()` helper

Closes #151