### PR TITLE
ci: update Manki to v3 with reviewer/judge model split

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -27,13 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
       - name: Manki
-        uses: xdustinface/manki@main
+        uses: xdustinface/manki@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.manki.yml
+++ b/.manki.yml
@@ -1,4 +1,7 @@
 model: claude-opus-4-6
+models:
+  reviewer: claude-sonnet-4-6
+  judge: claude-opus-4-6
 
 auto_review: true
 auto_approve: true


### PR DESCRIPTION
## Summary

- Update Manki action from `@main` to `@v3`
- Remove setup-node and npm install steps (v3 ships pre-built dist/)
- Add `models` config: Sonnet 4.6 for bulk reviewer work, Opus 4.6 for final judge evaluation