### PR TITLE
feat(ui): add confirm dialog when closing session tabs

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -9,6 +9,7 @@ use serde_yaml::to_string as to_yaml;
 use tracing::error;
 
 use crate::components::backlog_tab::BacklogTab;
+use crate::components::confirm_dialog::ConfirmDialog;
 use crate::components::home_dashboard::HomeDashboard;
 use crate::components::quick_capture::QuickCapture;
 use crate::components::session_creator::{SessionCreator, SessionSource};
@@ -111,6 +112,7 @@ pub(crate) fn App() -> Element {
 
     let mut showing_creator = use_signal(|| false);
     let mut showing_quick_capture = use_signal(|| false);
+    let mut pending_close_tab: Signal<Option<usize>> = use_signal(|| None);
 
     // Per-session engine event receivers and live state
     let mut engine_receivers: crate::engine_bridge::EngineReceivers = use_signal(HashMap::new);
@@ -161,7 +163,7 @@ pub(crate) fn App() -> Element {
     };
 
     let repo_for_close = default_repo.clone();
-    let on_close_tab = move |idx: usize| {
+    let mut do_close_tab = move |idx: usize| {
         let mut t = tabs.write();
         if idx < t.len() {
             let closed_sid = t[idx].session_id.clone();
@@ -195,6 +197,10 @@ pub(crate) fn App() -> Element {
                 }
             }
         }
+    };
+
+    let on_close_tab = move |idx: usize| {
+        pending_close_tab.set(Some(idx));
     };
 
     let on_new_tab = move |()| {
@@ -377,31 +383,15 @@ pub(crate) fn App() -> Element {
                         if let ActivePane::Session(idx) = current {
                             let t = tabs.read();
                             if idx < t.len() {
-                                let closed_sid = t[idx].session_id.clone();
-                                let closed_id_str = closed_sid.as_str().to_string();
                                 drop(t);
-
-                                tabs.write().remove(idx);
-                                engine_receivers.write().remove(&closed_sid);
-                                live_states.write().remove(&closed_sid);
-
-                                let len = tabs.read().len();
-                                let repo_key = repo_for_keys.clone().unwrap_or_default();
-                                let mut ws = window_state.write();
-                                ws.update_tab(&repo_key, &closed_id_str, false);
-                                save_window_state(&ws);
-                                drop(ws);
-
-                                if len == 0 {
-                                    active_pane.set(ActivePane::Home);
-                                } else if idx >= len {
-                                    active_pane.set(ActivePane::Session(len - 1));
-                                }
+                                pending_close_tab.set(Some(idx));
                             }
                         }
                     }
                     "escape" => {
-                        if *showing_quick_capture.read() {
+                        if pending_close_tab.read().is_some() {
+                            pending_close_tab.set(None);
+                        } else if *showing_quick_capture.read() {
                             showing_quick_capture.set(false);
                         } else if *showing_creator.read() {
                             showing_creator.set(false);
@@ -495,6 +485,23 @@ pub(crate) fn App() -> Element {
                 QuickCapture {
                     context: quick_capture_context.clone(),
                     on_dismiss: on_dismiss_quick_capture,
+                }
+            }
+            if pending_close_tab.read().is_some() {
+                ConfirmDialog {
+                    title: "Close session?".to_string(),
+                    message: "The terminal output will be lost.".to_string(),
+                    confirm_label: "Close".to_string(),
+                    on_confirm: move |()| {
+                        let idx = *pending_close_tab.read();
+                        pending_close_tab.set(None);
+                        if let Some(idx) = idx {
+                            do_close_tab(idx);
+                        }
+                    },
+                    on_cancel: move |()| {
+                        pending_close_tab.set(None);
+                    },
                 }
             }
             ToastContainer {}

--- a/crates/ui/src/components/confirm_dialog.rs
+++ b/crates/ui/src/components/confirm_dialog.rs
@@ -1,0 +1,35 @@
+use dioxus::prelude::*;
+
+#[component]
+pub(crate) fn ConfirmDialog(
+    title: String,
+    message: String,
+    confirm_label: String,
+    on_confirm: EventHandler<()>,
+    on_cancel: EventHandler<()>,
+) -> Element {
+    rsx! {
+        div {
+            class: "confirm-dialog-overlay",
+            onclick: move |_| on_cancel.call(()),
+            div {
+                class: "confirm-dialog",
+                onclick: move |evt| evt.stop_propagation(),
+                h3 { "{title}" }
+                p { class: "confirm-dialog-message", "{message}" }
+                div { class: "confirm-dialog-actions",
+                    button {
+                        class: "confirm-dialog-btn cancel",
+                        onclick: move |_| on_cancel.call(()),
+                        "Cancel"
+                    }
+                    button {
+                        class: "confirm-dialog-btn confirm",
+                        onclick: move |_| on_confirm.call(()),
+                        "{confirm_label}"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod backlog_tab;
+pub(crate) mod confirm_dialog;
 pub(crate) mod home_dashboard;
 pub(crate) mod quick_capture;
 pub(crate) mod session_creator;

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -1267,4 +1267,78 @@ body {
     color: var(--text-tertiary);
     text-align: center;
 }
+
+/* Confirm dialog */
+.confirm-dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(12, 14, 18, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 300;
+}
+
+.confirm-dialog {
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+    min-width: 320px;
+    max-width: 400px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+.confirm-dialog h3 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+}
+
+.confirm-dialog-message {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: var(--space-5);
+    line-height: 1.5;
+}
+
+.confirm-dialog-actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+}
+
+.confirm-dialog-btn {
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.confirm-dialog-btn.cancel {
+    background: none;
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+}
+
+.confirm-dialog-btn.cancel:hover {
+    background-color: var(--surface-3);
+    color: var(--text-primary);
+}
+
+.confirm-dialog-btn.confirm {
+    background-color: var(--status-error);
+    border: none;
+    color: var(--text-primary);
+}
+
+.confirm-dialog-btn.confirm:hover {
+    background-color: #d47a7a;
+}
 "#;


### PR DESCRIPTION
## Summary

- Confirm dialog appears when clicking X on a session tab or pressing Cmd+W
- "Close session? The terminal output will be lost." with Close/Cancel buttons
- Escape key and backdrop click dismiss the dialog
- Reusable `ConfirmDialog` component for future use

Closes #166