### PR TITLE
feat(ui): rename "Ready" button to "Humanize"

### DIFF
--- a/crates/ui/src/components/home_dashboard.rs
+++ b/crates/ui/src/components/home_dashboard.rs
@@ -518,7 +518,7 @@ pub(crate) fn HomeDashboard(
                                                                 });
                                                             }
                                                         },
-                                                        if is_removing { "Removing..." } else { "Ready" }
+                                                        if is_removing { "Humanizing..." } else { "Humanize" }
                                                     }
                                                 }
                                                 span { class: "dashboard-time", "{relative_time(&pr_clone.updated_at)}" }


### PR DESCRIPTION
## Summary
- Rename "Ready" button to "Humanize" on PR cards with `needs-human` label
- Loading state text changed from "Removing..." to "Humanizing..."

Closes #178