### PR TITLE
fix(ui): align terminal content flush with container edges

### DIFF
--- a/crates/ui/src/components/terminal_view.rs
+++ b/crates/ui/src/components/terminal_view.rs
@@ -37,6 +37,8 @@ fn xterm_init_js(tid: &str) -> String {
                 scrollback: 10000,
                 convertEol: true,
                 allowTransparency: true,
+                overviewRulerLanes: 0,
+                scrollbarStyle: 'overlay',
             }});
             term.open(el);
             let fitAddon = new FitAddon.FitAddon();

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -706,10 +706,23 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
+    padding: 0;
 }
 
 .terminal-xterm-container .xterm-viewport {
     overflow-y: auto !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+.terminal-xterm-container .xterm-screen {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+.terminal-xterm-container .xterm-viewport::-webkit-scrollbar {
+    width: 0;
+    display: none;
 }
 
 /* Toast notifications */


### PR DESCRIPTION
## Summary
- Strip xterm.js internal padding/margin on `.xterm-viewport` and `.xterm-screen` via CSS overrides
- Hide WebKit scrollbar on viewport to reclaim right-edge space
- Add `overviewRulerLanes: 0` and `scrollbarStyle: 'overlay'` to xterm options

Closes #140