### PR TITLE
feat(ui): add hover-to-reveal sidebar with optional pin

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -13,6 +13,7 @@ use crate::components::confirm_dialog::ConfirmDialog;
 use crate::components::home_dashboard::HomeDashboard;
 use crate::components::quick_capture::QuickCapture;
 use crate::components::session_creator::{SessionCreator, SessionSource};
+use crate::components::sidebar::Sidebar;
 use crate::components::tab_bar::TabBar;
 use crate::components::toast::{ToastContainer, ToastLevel, Toasts, push_toast};
 use crate::components::workflow_view::WorkflowView;
@@ -121,6 +122,7 @@ pub(crate) fn App() -> Element {
     let mut showing_creator = use_signal(|| false);
     let mut showing_quick_capture = use_signal(|| false);
     let mut pending_close_tab: Signal<Option<usize>> = use_signal(|| None);
+    let mut sidebar_pinned = use_signal(|| false);
 
     // Per-session engine event receivers and live state
     let mut engine_receivers: crate::engine_bridge::EngineReceivers = use_signal(HashMap::new);
@@ -164,6 +166,18 @@ pub(crate) fn App() -> Element {
         let tabs_read = tabs.read();
         if let Some(tab) = tabs_read.get(idx) {
             let repo_key = repo_for_select.clone().unwrap_or_default();
+            let mut ws = window_state.write();
+            ws.set_active(&repo_key, tab.session_id.as_str());
+            save_window_state(&ws);
+        }
+    };
+
+    let repo_for_sidebar_select = default_repo.clone();
+    let on_sidebar_select = move |idx: usize| {
+        active_pane.set(ActivePane::Session(idx));
+        let tabs_read = tabs.read();
+        if let Some(tab) = tabs_read.get(idx) {
+            let repo_key = repo_for_sidebar_select.clone().unwrap_or_default();
             let mut ws = window_state.write();
             ws.set_active(&repo_key, tab.session_id.as_str());
             save_window_state(&ws);
@@ -403,6 +417,8 @@ pub(crate) fn App() -> Element {
                             showing_quick_capture.set(false);
                         } else if *showing_creator.read() {
                             showing_creator.set(false);
+                        } else if *sidebar_pinned.read() {
+                            sidebar_pinned.set(false);
                         }
                     }
                     other => {
@@ -440,6 +456,12 @@ pub(crate) fn App() -> Element {
         showing_quick_capture.set(false);
     };
 
+    let main_content_class = if *sidebar_pinned.read() {
+        "main-content sidebar-pinned"
+    } else {
+        "main-content"
+    };
+
     rsx! {
         div { class: "app-layout",
             TabBar {
@@ -453,7 +475,14 @@ pub(crate) fn App() -> Element {
                 on_close: on_close_tab,
                 on_new: on_new_tab,
             }
-            div { class: "main-content",
+            Sidebar {
+                pinned: sidebar_pinned,
+                tabs: tabs.read().clone(),
+                active_session_idx: session_idx,
+                on_session_select: on_sidebar_select,
+                on_new_session: on_new_tab,
+            }
+            div { class: "{main_content_class}",
                 if is_home {
                     HomeDashboard {
                         key: "{default_repo.clone().unwrap_or_default()}",

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod confirm_dialog;
 pub(crate) mod home_dashboard;
 pub(crate) mod quick_capture;
 pub(crate) mod session_creator;
+pub(crate) mod sidebar;
 pub(crate) mod split_pane;
 pub(crate) mod step_card;
 pub(crate) mod tab_bar;

--- a/crates/ui/src/components/sidebar.rs
+++ b/crates/ui/src/components/sidebar.rs
@@ -1,0 +1,122 @@
+use dioxus::prelude::*;
+use fridi_core::session::SessionStatus;
+
+use crate::state::TabInfo;
+
+#[component]
+pub(crate) fn Sidebar(
+    pinned: Signal<bool>,
+    tabs: Vec<TabInfo>,
+    active_session_idx: Option<usize>,
+    on_session_select: EventHandler<usize>,
+    on_new_session: EventHandler<()>,
+) -> Element {
+    let mut hovered = use_signal(|| false);
+    let is_pinned = *pinned.read();
+    let is_expanded = is_pinned || *hovered.read();
+
+    let sidebar_class = if is_pinned {
+        "sidebar expanded pinned"
+    } else if is_expanded {
+        "sidebar expanded"
+    } else {
+        "sidebar"
+    };
+
+    let pin_label = if is_pinned { "Unpin" } else { "Pin" };
+
+    rsx! {
+        // Backdrop when expanded but not pinned
+        if is_expanded && !is_pinned {
+            div {
+                class: "sidebar-backdrop",
+                onclick: move |_| {
+                    hovered.set(false);
+                },
+            }
+        }
+
+        // Hover edge strip (always visible)
+        div {
+            class: "sidebar-edge",
+            onmouseenter: move |_| {
+                hovered.set(true);
+            },
+        }
+
+        // Sidebar panel
+        div {
+            class: "{sidebar_class}",
+            onmouseenter: move |_| {
+                hovered.set(true);
+            },
+            onmouseleave: move |_| {
+                if !is_pinned {
+                    hovered.set(false);
+                }
+            },
+
+            // Header
+            div { class: "sidebar-header",
+                span { class: "sidebar-brand", "fridi" }
+                button {
+                    class: "sidebar-pin-btn",
+                    title: "{pin_label}",
+                    onclick: move |_| {
+                        let current = *pinned.read();
+                        pinned.set(!current);
+                    },
+                    if is_pinned { "||" } else { ">>" }
+                }
+            }
+
+            // Sessions section
+            div { class: "sidebar-section",
+                div { class: "sidebar-section-header",
+                    span { "Sessions" }
+                    button {
+                        class: "sidebar-add-btn",
+                        onclick: move |_| on_new_session.call(()),
+                        "+"
+                    }
+                }
+                if tabs.is_empty() {
+                    div { class: "sidebar-empty", "No sessions" }
+                } else {
+                    div { class: "sidebar-list",
+                        for (idx , tab) in tabs.iter().enumerate() {
+                            {
+                                let is_active = active_session_idx == Some(idx);
+                                let item_class = if is_active {
+                                    "sidebar-item active"
+                                } else {
+                                    "sidebar-item"
+                                };
+                                let status_class = match &tab.status {
+                                    SessionStatus::Running => "running",
+                                    SessionStatus::Completed => "completed",
+                                    SessionStatus::Failed => "failed",
+                                    SessionStatus::Interrupted => "failed",
+                                };
+                                rsx! {
+                                    div {
+                                        key: "{tab.session_id}",
+                                        class: "{item_class}",
+                                        onclick: move |_| on_session_select.call(idx),
+                                        div { class: "status-dot {status_class}" }
+                                        span { class: "sidebar-item-name", "{tab.workflow_name}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Footer with keyboard hint
+            div { class: "sidebar-footer",
+                span { class: "sidebar-hint", "Esc to close" }
+            }
+        }
+    }
+}

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -1684,4 +1684,187 @@ body {
     background-color: var(--accent);
     color: var(--text-primary);
 }
+
+/* Sidebar */
+.sidebar-edge {
+    position: fixed;
+    left: 0;
+    top: 40px;
+    width: 4px;
+    height: calc(100vh - 40px);
+    background-color: var(--border-subtle);
+    z-index: 50;
+    cursor: pointer;
+    transition: background-color var(--transition-normal);
+}
+
+.sidebar-edge:hover {
+    background-color: var(--accent);
+}
+
+.sidebar {
+    position: fixed;
+    left: 0;
+    top: 40px;
+    width: 280px;
+    height: calc(100vh - 40px);
+    background-color: var(--surface-1);
+    border-right: 1px solid var(--border-default);
+    z-index: 49;
+    transform: translateX(-280px);
+    transition: transform var(--transition-slow);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.sidebar.expanded {
+    transform: translateX(0);
+    box-shadow: 8px 0 24px rgba(0, 0, 0, 0.3);
+}
+
+.sidebar.pinned {
+    box-shadow: none;
+}
+
+.sidebar-backdrop {
+    position: fixed;
+    top: 40px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(12, 14, 18, 0.5);
+    backdrop-filter: blur(4px);
+    z-index: 48;
+}
+
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-4) var(--space-4);
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+}
+
+.sidebar-brand {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--accent);
+    letter-spacing: -0.5px;
+}
+
+.sidebar-pin-btn {
+    background: none;
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 11px;
+    font-family: var(--font-mono);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition-normal), color var(--transition-normal), border-color var(--transition-normal);
+}
+
+.sidebar-pin-btn:hover {
+    background-color: var(--surface-3);
+    color: var(--text-primary);
+    border-color: var(--accent);
+}
+
+.sidebar-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: var(--space-3) 0;
+}
+
+.sidebar-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-4) var(--space-2) var(--space-4);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.sidebar-add-btn {
+    background: none;
+    border: 1px solid var(--border-default);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 13px;
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-sm);
+    line-height: 1.4;
+    transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+.sidebar-add-btn:hover {
+    background-color: var(--surface-3);
+    color: var(--accent);
+}
+
+.sidebar-list {
+    overflow-y: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 0 var(--space-2);
+}
+
+.sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color var(--transition-normal);
+}
+
+.sidebar-item:hover {
+    background-color: var(--surface-2);
+}
+
+.sidebar-item.active {
+    background-color: var(--surface-2);
+    border-left: 2px solid var(--accent);
+}
+
+.sidebar-item-name {
+    font-size: 13px;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+
+.sidebar-empty {
+    padding: var(--space-4);
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-tertiary);
+}
+
+.sidebar-footer {
+    padding: var(--space-3) var(--space-4);
+    border-top: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+}
+
+.sidebar-hint {
+    font-size: 11px;
+    color: var(--text-tertiary);
+}
+
+.main-content.sidebar-pinned {
+    margin-left: 280px;
+}
 "#;


### PR DESCRIPTION
## Summary
- Add `Sidebar` component with 4px always-visible left edge that expands to 280px on hover
- Shows session list with status dots, pin/unpin toggle, and new session button
- When pinned, shifts main content rightward; when unpinned, overlays with backdrop blur
- Escape key and backdrop click to close

Closes #71