### PR TITLE
ci: disable multi-stage review in manki

### DIFF
--- a/.manki.yml
+++ b/.manki.yml
@@ -5,7 +5,7 @@ models:
 
 auto_review: true
 auto_approve: true
-review_passes: 3
+review_passes: 1
 
 exclude_paths:
   - "*.lock"


### PR DESCRIPTION
## Summary
- Set `review_passes` from 3 back to 1 in `.manki.yml`