### PR TITLE
ci: remove @claude review trigger from Manki workflow

### DIFF
--- a/.github/workflows/manki.yml
+++ b/.github/workflows/manki.yml
@@ -20,7 +20,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
-       (contains(github.event.comment.body, '@manki review') || contains(github.event.comment.body, '@claude review')) &&
+       contains(github.event.comment.body, '@manki review') &&
        github.event.issue.pull_request)
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Remove `@claude review` as an alternative trigger for Manki reviews
- Only `@manki review` triggers re-reviews now