### PR TITLE
feat(ui): add Cmd+P command palette for instant session creation

### DIFF
--- a/crates/ui/src/app.rs
+++ b/crates/ui/src/app.rs
@@ -9,6 +9,7 @@ use serde_yaml::to_string as to_yaml;
 use tracing::error;
 
 use crate::components::backlog_tab::BacklogTab;
+use crate::components::command_palette::CommandPalette;
 use crate::components::confirm_dialog::ConfirmDialog;
 use crate::components::home_dashboard::HomeDashboard;
 use crate::components::quick_capture::QuickCapture;
@@ -112,6 +113,7 @@ pub(crate) fn App() -> Element {
     });
 
     let mut showing_creator = use_signal(|| false);
+    let mut showing_command_palette = use_signal(|| false);
     let mut showing_quick_capture = use_signal(|| false);
     let mut pending_close_tab: Signal<Option<usize>> = use_signal(|| None);
     let mut sidebar_pinned = use_signal(|| false);
@@ -339,6 +341,7 @@ pub(crate) fn App() -> Element {
     };
 
     let on_create_session = create_session.clone();
+    let mut on_palette_create = create_session.clone();
     let on_pick_issue = create_session;
 
     let on_cancel_creator = move |()| {
@@ -371,6 +374,9 @@ pub(crate) fn App() -> Element {
                 if (mod && e.key === 'b') {
                     e.preventDefault();
                     dioxus.send('toggle-quick-capture');
+                } else if (mod && e.key === 'p') {
+                    e.preventDefault();
+                    dioxus.send('toggle-command-palette');
                 } else if (mod && e.key === 't') {
                     e.preventDefault();
                     dioxus.send('new-session');
@@ -395,6 +401,9 @@ pub(crate) fn App() -> Element {
                     "toggle-quick-capture" => {
                         showing_quick_capture.toggle();
                     }
+                    "toggle-command-palette" => {
+                        showing_command_palette.toggle();
+                    }
                     "new-session" => {
                         showing_creator.set(true);
                     }
@@ -411,6 +420,8 @@ pub(crate) fn App() -> Element {
                     "escape" => {
                         if pending_close_tab.read().is_some() {
                             pending_close_tab.set(None);
+                        } else if *showing_command_palette.read() {
+                            showing_command_palette.set(false);
                         } else if *showing_quick_capture.read() {
                             showing_quick_capture.set(false);
                         } else if *showing_creator.read() {
@@ -514,6 +525,19 @@ pub(crate) fn App() -> Element {
                     repo: default_repo.clone(),
                     on_create: on_create_session,
                     on_cancel: on_cancel_creator,
+                    on_open_palette: move |_| {
+                        showing_creator.set(false);
+                        showing_command_palette.set(true);
+                    },
+                }
+            }
+            if *showing_command_palette.read() {
+                CommandPalette {
+                    on_create: move |source| {
+                        showing_command_palette.set(false);
+                        on_palette_create(source);
+                    },
+                    on_dismiss: move |_| showing_command_palette.set(false),
                 }
             }
             if *showing_quick_capture.read() {

--- a/crates/ui/src/components/command_palette.rs
+++ b/crates/ui/src/components/command_palette.rs
@@ -1,0 +1,82 @@
+use dioxus::prelude::*;
+
+use crate::components::session_creator::SessionSource;
+
+#[component]
+pub(crate) fn CommandPalette(
+    on_create: EventHandler<SessionSource>,
+    on_dismiss: EventHandler<()>,
+) -> Element {
+    let mut input_text = use_signal(String::new);
+
+    let submit = move |_| {
+        let text = input_text.read().trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        let source = parse_input(&text);
+        on_create.call(source);
+    };
+
+    let on_key = {
+        move |evt: KeyboardEvent| match evt.key() {
+            Key::Enter => {
+                evt.prevent_default();
+                submit(());
+            }
+            Key::Escape => {
+                on_dismiss.call(());
+            }
+            _ => {}
+        }
+    };
+
+    rsx! {
+        div {
+            class: "command-palette-backdrop",
+            onclick: move |_| on_dismiss.call(()),
+            div {
+                class: "command-palette",
+                onclick: move |evt| evt.stop_propagation(),
+                onkeydown: on_key,
+                input {
+                    class: "command-palette-input",
+                    placeholder: "Describe what you want to work on... (#issue, !pr)",
+                    value: "{input_text}",
+                    oninput: move |evt| input_text.set(evt.value()),
+                    onmounted: move |evt: MountedEvent| {
+                        spawn(async move {
+                            let _ = evt.set_focus(true).await;
+                        });
+                    },
+                }
+                div { class: "command-palette-hint",
+                    "Enter to start \u{00b7} Esc to close \u{00b7} #N for issue \u{00b7} !N for PR"
+                }
+            }
+        }
+    }
+}
+
+fn parse_input(text: &str) -> SessionSource {
+    if let Some(rest) = text.strip_prefix('#') {
+        if let Ok(number) = rest.parse::<u64>() {
+            return SessionSource::Issue {
+                number,
+                title: format!("Issue #{number}"),
+            };
+        }
+    }
+    if let Some(rest) = text.strip_prefix('!') {
+        if let Ok(number) = rest.parse::<u64>() {
+            return SessionSource::PR {
+                number,
+                title: format!("PR #{number}"),
+                head_ref: String::new(),
+            };
+        }
+    }
+    SessionSource::Prompt {
+        text: text.to_string(),
+    }
+}

--- a/crates/ui/src/components/command_palette.rs
+++ b/crates/ui/src/components/command_palette.rs
@@ -59,8 +59,9 @@ pub(crate) fn CommandPalette(
 }
 
 fn parse_input(text: &str) -> SessionSource {
+    let text = text.trim();
     if let Some(rest) = text.strip_prefix('#') {
-        if let Ok(number) = rest.parse::<u64>() {
+        if let Ok(number) = rest.trim().parse::<u64>() {
             return SessionSource::Issue {
                 number,
                 title: format!("Issue #{number}"),
@@ -68,15 +69,97 @@ fn parse_input(text: &str) -> SessionSource {
         }
     }
     if let Some(rest) = text.strip_prefix('!') {
-        if let Ok(number) = rest.parse::<u64>() {
+        if let Ok(number) = rest.trim().parse::<u64>() {
             return SessionSource::PR {
                 number,
                 title: format!("PR #{number}"),
-                head_ref: String::new(),
+                head_ref: format!("pr/{number}"),
             };
         }
     }
     SessionSource::Prompt {
         text: text.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_issue_number() {
+        let result = parse_input("#123");
+        assert!(matches!(result, SessionSource::Issue { number: 123, .. }));
+    }
+
+    #[test]
+    fn parse_pr_number() {
+        let result = parse_input("!45");
+        match result {
+            SessionSource::PR {
+                number, head_ref, ..
+            } => {
+                assert_eq!(number, 45);
+                assert_eq!(head_ref, "pr/45");
+            }
+            other => panic!("expected PR, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_plain_text() {
+        let result = parse_input("fix the login bug");
+        match result {
+            SessionSource::Prompt { text } => assert_eq!(text, "fix the login bug"),
+            other => panic!("expected Prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_whitespace_around_prefix() {
+        assert!(matches!(
+            parse_input("  #123  "),
+            SessionSource::Issue { number: 123, .. }
+        ));
+        assert!(matches!(
+            parse_input("  !45  "),
+            SessionSource::PR { number: 45, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_whitespace_after_prefix() {
+        assert!(matches!(
+            parse_input("# 123"),
+            SessionSource::Issue { number: 123, .. }
+        ));
+        assert!(matches!(
+            parse_input("! 45"),
+            SessionSource::PR { number: 45, .. }
+        ));
+    }
+
+    #[test]
+    fn parse_non_numeric_after_prefix_falls_back_to_prompt() {
+        assert!(matches!(parse_input("#abc"), SessionSource::Prompt { .. }));
+        assert!(matches!(parse_input("!xyz"), SessionSource::Prompt { .. }));
+    }
+
+    #[test]
+    fn parse_empty_and_whitespace_only_returns_prompt() {
+        match parse_input("") {
+            SessionSource::Prompt { text } => assert_eq!(text, ""),
+            other => panic!("expected Prompt, got {other:?}"),
+        }
+        match parse_input("   ") {
+            SessionSource::Prompt { text } => assert_eq!(text, ""),
+            other => panic!("expected Prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_prefix_alone_falls_back_to_prompt() {
+        assert!(matches!(parse_input("#"), SessionSource::Prompt { .. }));
+        assert!(matches!(parse_input("!"), SessionSource::Prompt { .. }));
     }
 }

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod backlog_tab;
+pub(crate) mod command_palette;
 pub(crate) mod confirm_dialog;
 pub(crate) mod home_dashboard;
 pub(crate) mod quick_capture;

--- a/crates/ui/src/components/session_creator.rs
+++ b/crates/ui/src/components/session_creator.rs
@@ -55,6 +55,7 @@ pub(crate) fn SessionCreator(
     repo: Option<String>,
     on_create: EventHandler<SessionSource>,
     on_cancel: EventHandler<()>,
+    on_open_palette: Option<EventHandler<()>>,
 ) -> Element {
     let mut mode = use_signal(|| CreatorMode::SelectMode);
     let mut issues = use_signal(|| None::<LoadState<Vec<GitHubIssue>>>);
@@ -162,11 +163,21 @@ pub(crate) fn SessionCreator(
                             button {
                                 class: "mode-btn",
                                 onclick: move |_| {
-                                    mode.set(CreatorMode::NewPrompt);
-                                    prompt_text.set(String::new());
+                                    if let Some(handler) = &on_open_palette {
+                                        handler.call(());
+                                    } else {
+                                        mode.set(CreatorMode::NewPrompt);
+                                        prompt_text.set(String::new());
+                                    }
                                 },
                                 div { class: "mode-btn-title", "New by Prompt" }
-                                div { class: "mode-btn-desc", "Describe the task" }
+                                div { class: "mode-btn-desc",
+                                    if on_open_palette.is_some() {
+                                        "Describe the task (Cmd+P)"
+                                    } else {
+                                        "Describe the task"
+                                    }
+                                }
                             }
                         }
                         if !has_repo {

--- a/crates/ui/src/styles.rs
+++ b/crates/ui/src/styles.rs
@@ -1915,4 +1915,71 @@ body {
 .main-content.sidebar-pinned {
     margin-left: 280px;
 }
+
+/* Command palette */
+.command-palette-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(12, 14, 18, 0.7);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 20vh;
+    z-index: 250;
+    animation: fade-in 0.12s ease-out;
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.command-palette {
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    width: 500px;
+    max-width: 90vw;
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+    animation: palette-slide-in 0.12s ease-out;
+}
+
+@keyframes palette-slide-in {
+    from { opacity: 0; transform: translateY(-8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.command-palette-input {
+    width: 100%;
+    padding: var(--space-3) var(--space-4);
+    background-color: transparent;
+    border: none;
+    border-bottom: 2px solid var(--border-default);
+    color: var(--text-primary);
+    font-size: 16px;
+    font-family: var(--font-sans);
+    outline: none;
+    transition: border-color var(--transition-normal);
+}
+
+.command-palette-input:focus {
+    border-bottom-color: var(--accent);
+}
+
+.command-palette-input::placeholder {
+    color: var(--text-secondary);
+}
+
+.command-palette-hint {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    text-align: center;
+}
 "#;


### PR DESCRIPTION
## Summary
- Add floating Cmd+P command palette with smart routing: plain text → prompt, `#N` → issue, `!N` → PR
- "New by Prompt" card in session creator now opens the palette with Cmd+P hint
- Escape or backdrop click to dismiss, auto-focused input

Closes #198